### PR TITLE
Add language parameter to matrix configuration.

### DIFF
--- a/lib/google_distance_matrix/configuration.rb
+++ b/lib/google_distance_matrix/configuration.rb
@@ -9,7 +9,7 @@ module GoogleDistanceMatrix
   class Configuration
     include ActiveModel::Validations
 
-    ATTRIBUTES = %w[sensor mode avoid units]
+    ATTRIBUTES = %w[sensor mode avoid units language]
 
     API_DEFAULTS = {
       mode: "driving",


### PR DESCRIPTION
As described in [Google's documentation](https://developers.google.com/maps/documentation/distancematrix/#RequestParameters) it's possible to set the language in which the results will be given.
