### PR TITLE
Update matrix configuration to match current API

### DIFF
--- a/google_distance_matrix.gemspec
+++ b/google_distance_matrix.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "shoulda-matchers", "~> 2.6.2"
   spec.add_development_dependency "webmock", "~> 1.18.0"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "pry"
 end

--- a/lib/google_distance_matrix/configuration.rb
+++ b/lib/google_distance_matrix/configuration.rb
@@ -9,7 +9,7 @@ module GoogleDistanceMatrix
   class Configuration
     include ActiveModel::Validations
 
-    ATTRIBUTES = %w[sensor mode avoid units language]
+    ATTRIBUTES = %w[sensor mode avoid units language departure_time arrival_time transit_mode]
 
     API_DEFAULTS = {
       mode: "driving",
@@ -25,6 +25,11 @@ module GoogleDistanceMatrix
     validates :mode, inclusion: {in: ["driving", "walking", "bicycling", "transit"]}, allow_blank: true
     validates :avoid, inclusion: {in: ["tolls", "highways"]}, allow_blank: true
     validates :units, inclusion: {in: ["metric", "imperial"]}, allow_blank: true
+
+    validates :departure_time, numericality: true, allow_blank: true
+    validates :arrival_time, numericality: true, allow_blank: true
+
+    validates :transit_mode, inclusion: {in: %w[bus subway train tram rail]}, allow_blank: true
 
     validates :protocol, inclusion: {in: ["http", "https"]}, allow_blank: true
 

--- a/lib/google_distance_matrix/configuration.rb
+++ b/lib/google_distance_matrix/configuration.rb
@@ -22,7 +22,7 @@ module GoogleDistanceMatrix
 
 
     validates :sensor, inclusion: {in: [true, false]}
-    validates :mode, inclusion: {in: ["driving", "walking", "bicycling"]}, allow_blank: true
+    validates :mode, inclusion: {in: ["driving", "walking", "bicycling", "transit"]}, allow_blank: true
     validates :avoid, inclusion: {in: ["tolls", "highways"]}, allow_blank: true
     validates :units, inclusion: {in: ["metric", "imperial"]}, allow_blank: true
 

--- a/lib/google_distance_matrix/configuration.rb
+++ b/lib/google_distance_matrix/configuration.rb
@@ -17,7 +17,7 @@ module GoogleDistanceMatrix
     }.with_indifferent_access
 
     attr_accessor *ATTRIBUTES, :protocol, :logger, :lat_lng_scale
-    attr_accessor :google_business_api_client_id, :google_business_api_private_key
+    attr_accessor :google_business_api_client_id, :google_business_api_private_key, :google_api_key
     attr_accessor :cache
 
 
@@ -57,6 +57,10 @@ module GoogleDistanceMatrix
 
       if google_business_api_client_id.present?
         out << ['client', google_business_api_client_id]
+      end
+
+      if google_api_key.present?
+        out << ['key', google_api_key]
       end
 
       out

--- a/lib/google_distance_matrix/url_builder.rb
+++ b/lib/google_distance_matrix/url_builder.rb
@@ -39,6 +39,10 @@ module GoogleDistanceMatrix
       configuration.google_business_api_private_key.present?
     end
 
+    def include_api_key?
+      configuration.google_api_key.present?
+    end
+
     def get_params_string
       params.to_a.map { |key_value| key_value.join("=") }.join("&")
     end

--- a/spec/lib/google_distance_matrix/configuration_spec.rb
+++ b/spec/lib/google_distance_matrix/configuration_spec.rb
@@ -24,7 +24,7 @@ describe GoogleDistanceMatrix::Configuration do
       end
     end
 
-    it { should ensure_inclusion_of(:mode).in_array(["driving", "walking", "bicycling"]) }
+    it { should ensure_inclusion_of(:mode).in_array(["driving", "walking", "bicycling", "transit"]) }
     it { should allow_value(nil).for(:mode) }
 
     it { should ensure_inclusion_of(:avoid).in_array(["tolls", "highways"]) }

--- a/spec/lib/google_distance_matrix/configuration_spec.rb
+++ b/spec/lib/google_distance_matrix/configuration_spec.rb
@@ -48,6 +48,7 @@ describe GoogleDistanceMatrix::Configuration do
 
     it { expect(subject.google_business_api_client_id).to be_nil }
     it { expect(subject.google_business_api_private_key).to be_nil }
+    it { expect(subject.google_api_key).to be_nil }
 
     it { expect(subject.logger).to be_nil }
     it { expect(subject.cache).to be_nil }
@@ -78,6 +79,11 @@ describe GoogleDistanceMatrix::Configuration do
     it "includes client if google_business_api_client_id has been set" do
       subject.google_business_api_client_id = "123"
       expect(subject.to_param['client']).to eq "123"
+    end
+
+    it "includes key if google_api_key has been set" do
+      subject.google_api_key = "12345"
+      expect(subject.to_param['key']).to eq("12345")
     end
   end
 end

--- a/spec/lib/google_distance_matrix/configuration_spec.rb
+++ b/spec/lib/google_distance_matrix/configuration_spec.rb
@@ -24,6 +24,34 @@ describe GoogleDistanceMatrix::Configuration do
       end
     end
 
+    describe 'departure_time' do
+      it 'is valid with a timestamp' do
+        subject.departure_time = Time.now.to_i
+        subject.valid?
+        expect(subject.errors[:departure_time].length).to eq 0
+      end
+
+      it 'is invalid with something else' do
+        subject.departure_time = 'foo'
+        subject.valid?
+        expect(subject.errors[:departure_time].length).to eq 1
+      end
+    end
+
+    describe 'arrival_time' do
+      it 'is valid with a timestamp' do
+        subject.arrival_time = Time.now.to_i
+        subject.valid?
+        expect(subject.errors[:arrival_time].length).to eq 0
+      end
+
+      it 'is invalid with something else' do
+        subject.arrival_time = 'foo'
+        subject.valid?
+        expect(subject.errors[:arrival_time].length).to eq 1
+      end
+    end
+
     it { should ensure_inclusion_of(:mode).in_array(["driving", "walking", "bicycling", "transit"]) }
     it { should allow_value(nil).for(:mode) }
 
@@ -34,6 +62,8 @@ describe GoogleDistanceMatrix::Configuration do
     it { should allow_value(nil).for(:units) }
 
     it { should ensure_inclusion_of(:protocol).in_array(["http", "https"]) }
+
+    it { should ensure_inclusion_of(:transit_mode).in_array(["bus", "subway", "train", "tram", "rail"])}
   end
 
 
@@ -45,6 +75,10 @@ describe GoogleDistanceMatrix::Configuration do
     it { expect(subject.lat_lng_scale).to eq 5 }
     it { expect(subject.protocol).to eq 'http' }
     it { expect(subject.language).to be_nil }
+
+    it { expect(subject.departure_time).to be_nil }
+    it { expect(subject.arrival_time).to be_nil }
+    it { expect(subject.transit_mode).to be_nil }
 
     it { expect(subject.google_business_api_client_id).to be_nil }
     it { expect(subject.google_business_api_private_key).to be_nil }

--- a/spec/lib/google_distance_matrix/url_builder_spec.rb
+++ b/spec/lib/google_distance_matrix/url_builder_spec.rb
@@ -84,6 +84,18 @@ describe GoogleDistanceMatrix::UrlBuilder do
         expect(subject.url).to include "sensor=#{matrix.configuration.sensor}"
       end
 
+      context 'with google api key set' do
+        before do
+          matrix.configure do |config|
+            config.google_api_key = '12345'
+          end
+        end
+
+        it 'includes the api key' do
+          expect(subject.url).to include "key=#{matrix.configuration.google_api_key}"
+        end
+      end
+
       context "with google business client id and private key set" do
         before do
           matrix.configure do |config|


### PR DESCRIPTION
The current API has a number of parameters that the gem currently doesn't support, so I've added them.

Also resolves Issue #7.

See https://developers.google.com/maps/documentation/distance-matrix/intro for the parameter list.

New configuration parameters:
* `google_api_key`
* "transit" option for `mode`
* `transit_mode`
* `arrival_time`
* `departure_time`