### PR TITLE
Make https default protocol

### DIFF
--- a/lib/google_distance_matrix/configuration.rb
+++ b/lib/google_distance_matrix/configuration.rb
@@ -36,7 +36,7 @@ module GoogleDistanceMatrix
 
     def initialize
       self.sensor = false
-      self.protocol = "http"
+      self.protocol = "https"
       self.lat_lng_scale = 5
 
       API_DEFAULTS.each_pair do |attr_name, value|

--- a/spec/lib/google_distance_matrix/configuration_spec.rb
+++ b/spec/lib/google_distance_matrix/configuration_spec.rb
@@ -77,7 +77,7 @@ describe GoogleDistanceMatrix::Configuration do
     it { expect(subject.avoid).to be_nil }
     it { expect(subject.units).to eq "metric" }
     it { expect(subject.lat_lng_scale).to eq 5 }
-    it { expect(subject.protocol).to eq 'http' }
+    it { expect(subject.protocol).to eq 'https' }
     it { expect(subject.language).to be_nil }
 
     it { expect(subject.departure_time).to be_nil }

--- a/spec/lib/google_distance_matrix/url_builder_spec.rb
+++ b/spec/lib/google_distance_matrix/url_builder_spec.rb
@@ -53,12 +53,12 @@ describe GoogleDistanceMatrix::UrlBuilder do
     end
 
     it "starts with the base URL" do
-      expect(subject.url).to start_with "http://" + described_class::BASE_URL
+      expect(subject.url).to start_with "https://" + described_class::BASE_URL
     end
 
     it "has a configurable protocol" do
-      matrix.configure { |c| c.protocol = "https" }
-      expect(subject.url).to start_with "https://"
+      matrix.configure { |c| c.protocol = "http" }
+      expect(subject.url).to start_with "http://"
     end
 
     it "includes origins" do


### PR DESCRIPTION
Suggestion, with a push request to make the protocol be https by default. From what I see now there are no restrictions to having https be the default.

Currently if a person wants to add an API key to google_distance_matrix it will be refused, as it requires an https connection with an API key enabled. Thus I think it will remove a barrier of entry for new users of the gem as-well, as there is currently no documentation on how to change the protocol to https.