### PR TITLE
Support encoded polyline as request parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 before_install:
   - gem update bundler
 rvm:
-  - 2.0.0
   - 2.1.0
   - 2.1.2
   - 2.1.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v.0.4.0
+## v.0.4.0 (unreleased)
 * Added option to encode origins and destinations as polylines to save characters in the URL.
 * Dropped support for Ruby 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## v.0.3.0 (unreleased)
+## v.0.4.0
+* Added option to encode origins and destinations as polylines to save characters in the URL.
+* Dropped support for Ruby 2.0.0
+
+## v.0.3.0
 This release includes one breaking change, the removal of sensor parameter.
 This parameter is no longer used - see:
 https://developers.google.com/maps/documentation/distance-matrix/intro#Sensor

--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ matrix.configure do |config|
   config.google_business_api_client_id = "123"
   config.google_business_api_private_key = "your-secret-key"
 
-  # If you have an API key, you can specify that as well.	
+  # If you have an API key, you can specify that as well.
   config.google_api_key = "YOUR_API_KEY"
 end
 ```
 ### Get the data for the matrix
 
 `matrix.data` returns the data, loaded from Google, for this matrix.
- 
+
  It is a multi dimensional array. Rows are ordered according to the values in the origins.
  Each row corresponds to an origin, and each element within that row corresponds to a pairing of the origin with a destination.
 
@@ -81,9 +81,9 @@ Returns Google::DistanceMatrix::Route with given origin and destination
 ```ruby
 matrix.route_for origin: lat_lng, destination: dest_address
 # Google::DistanceMatrix::Route with one origin and a destination, together with route data
-matrix.shortest_route_by_distance_to(dest_address) 
+matrix.shortest_route_by_distance_to(dest_address)
 # Google::DistanceMatrix::Route with one origin and a destination, together with route data
-matrix.shortest_route_by_duration_to(dest_address) 
+matrix.shortest_route_by_duration_to(dest_address)
 ```
 
 In cases where you built the place with an object (not hash with attributes) you may provide that object as well asking for routes. This is true for `route_for` and `shortest_route_by_*` as well.
@@ -117,6 +117,19 @@ Configuration is done directly on a matrix or via `GoogleDistanceMatrix.configur
 Apart from configuration on requests it is also possible to provide your own logger class and
 set a cache.
 
+### Shorting the URL using encoded coordinates
+Instead of lat and lng values in the URL it is possible to use encoded set of coordinates
+using the Encoded Polyline Algorithm. This is particularly useful if you have a large
+number of origin points, because the URL is significantly shorter when
+using an encoded polyline.
+
+```ruby
+GoogleDistanceMatrix.configure_defaults do |config|
+  config.use_encoded_polylines = true
+end
+```
+
+
 ### Request cache
 
 Given Google's limit to the service you may have the need to cache requests. This is done by simply
@@ -124,10 +137,10 @@ using URL as cache keys. Cache we'll accept should provide a default ActiveSuppo
 
 ```ruby
 GoogleDistanceMatrix.configure_defaults do |config|
-    config.cache = ActiveSupport::Cache.lookup_store :your_store, {
-        expires_in: 12.hours
-        # ..or other options you like for your store
-    }
+  config.cache = ActiveSupport::Cache.lookup_store :your_store, {
+    expires_in: 12.hours
+    # ..or other options you like for your store
+  }
 end
 ```
 

--- a/lib/google_distance_matrix.rb
+++ b/lib/google_distance_matrix.rb
@@ -17,6 +17,7 @@ require "google_distance_matrix/matrix"
 require "google_distance_matrix/places"
 require "google_distance_matrix/place"
 require "google_distance_matrix/route"
+require "google_distance_matrix/polyline_encoder"
 
 require "google_distance_matrix/log_subscriber"
 require 'google_distance_matrix/railtie' if defined? Rails

--- a/lib/google_distance_matrix/place.rb
+++ b/lib/google_distance_matrix/place.rb
@@ -42,6 +42,10 @@ module GoogleDistanceMatrix
       end
     end
 
+    def lat_lng?
+      lat.present? && lng.present?
+    end
+
     def lat_lng(scale = nil)
       [lat, lng].map do |v|
         if scale

--- a/lib/google_distance_matrix/polyline_encoder.rb
+++ b/lib/google_distance_matrix/polyline_encoder.rb
@@ -1,0 +1,37 @@
+require_relative 'polyline_encoder/delta'
+
+module GoogleDistanceMatrix
+  # Encodes a set of lat/lng pairs in to a polyline
+  # according to Google's Encoded Polyline Algorithm Format.
+  #
+  # See https://developers.google.com/maps/documentation/utilities/polylinealgorithm
+  class PolylineEncoder
+
+    # Encodes a set of lat/lng pairs
+    #
+    # Example
+    #   encoded = PolylineEncoder.encode [[lat, lng], [lat, lng]]
+    def self.encode(array_of_lat_lng_pairs, precision: 1e5)
+      new(array_of_lat_lng_pairs, precision: precision).encode
+    end
+
+    # Initialize a new encoder
+    #
+    # @see ::encode
+    def initialize(array_of_lat_lng_pairs, precision: 1e5)
+      @array_of_lat_lng_pairs = array_of_lat_lng_pairs
+      @precision = precision
+      @encoded = nil
+    end
+
+    # Encode and returns the encoded string
+    def encode
+      return @encoded if @encoded
+
+      deltas = Delta.new(@array_of_lat_lng_pairs, precision: @precision).deltas
+
+
+      @encoded
+    end
+  end
+end

--- a/lib/google_distance_matrix/polyline_encoder.rb
+++ b/lib/google_distance_matrix/polyline_encoder.rb
@@ -1,4 +1,5 @@
 require_relative 'polyline_encoder/delta'
+require_relative 'polyline_encoder/value_encoder'
 
 module GoogleDistanceMatrix
   # Encodes a set of lat/lng pairs in to a polyline
@@ -11,16 +12,25 @@ module GoogleDistanceMatrix
     #
     # Example
     #   encoded = PolylineEncoder.encode [[lat, lng], [lat, lng]]
-    def self.encode(array_of_lat_lng_pairs, precision: 1e5)
-      new(array_of_lat_lng_pairs, precision: precision).encode
+    def self.encode(array_of_lat_lng_pairs)
+      new(array_of_lat_lng_pairs).encode
     end
+
 
     # Initialize a new encoder
     #
+    # Arguments
+    #   array_of_lat_lng_pairs    - The array of lat/lng pairs, like [[lat, lng], [lat, lng], ..etc]
+    #   delta                     - An object responsible for rounding and calculate the deltas
+    #                               between the given lat/lng pairs.
+    #   value_encoder             - After deltas are calculated each value is passed to the encoder
+    #                               to be encoded in to ASCII characters
+    #
     # @see ::encode
-    def initialize(array_of_lat_lng_pairs, precision: 1e5)
+    def initialize(array_of_lat_lng_pairs, delta: Delta.new, value_encoder: ValueEncoder.new)
       @array_of_lat_lng_pairs = array_of_lat_lng_pairs
-      @precision = precision
+      @delta = delta
+      @value_encoder = value_encoder
       @encoded = nil
     end
 
@@ -28,10 +38,10 @@ module GoogleDistanceMatrix
     def encode
       return @encoded if @encoded
 
-      deltas = Delta.new(@array_of_lat_lng_pairs, precision: @precision).deltas
+      deltas = @delta.deltas_rounded @array_of_lat_lng_pairs
+      chars_array = deltas.map { |v| @value_encoder.encode v }
 
-
-      @encoded
+      @encoded = chars_array.join
     end
   end
 end

--- a/lib/google_distance_matrix/polyline_encoder/delta.rb
+++ b/lib/google_distance_matrix/polyline_encoder/delta.rb
@@ -8,43 +8,44 @@ module GoogleDistanceMatrix
     #
     # @see GoogleDistanceMatrix::PolylineEncoder
     class Delta
-      def initialize(array_of_lat_lng_pairs, precision: 1e5)
-        @array_of_lat_lng_pairs = array_of_lat_lng_pairs
+      def initialize(precision = 1e5)
         @precision = precision
-        @deltas = nil
       end
 
-      def deltas
-        return @deltas if @deltas
-
-        round_to_precision
-        calculate_deltas
-
-        @deltas
+      # Takes a set of lat/lng pairs and calculates delta
+      #
+      # Returns a flatten array where each lat/lng delta pair is put in order.
+      def deltas_rounded(array_of_lat_lng_pairs)
+        rounded = round_to_precision array_of_lat_lng_pairs
+        calculate_deltas rounded
       end
 
 
       private
 
-      def round_to_precision
-        @array_of_lat_lng_pairs.each do |pair|
-          pair[0] = (pair[0] * @precision).round
-          pair[1] = (pair[1] * @precision).round
+      def round_to_precision(array_of_lat_lng_pairs)
+        array_of_lat_lng_pairs.map do |(lat, lng)|
+          [
+            (lat * @precision).round,
+            (lng * @precision).round
+          ]
         end
       end
 
-      def calculate_deltas
-        @deltas = []
+      def calculate_deltas(rounded)
+        deltas = []
 
         delta_lat = 0
         delta_lng = 0
 
-        @array_of_lat_lng_pairs.each do |(lat, lng)|
-          @deltas << lat - delta_lat
-          @deltas << lng - delta_lng
+        rounded.each do |(lat, lng)|
+          deltas << lat - delta_lat
+          deltas << lng - delta_lng
 
           delta_lat, delta_lng = lat, lng
         end
+
+        deltas
       end
     end
   end

--- a/lib/google_distance_matrix/polyline_encoder/delta.rb
+++ b/lib/google_distance_matrix/polyline_encoder/delta.rb
@@ -1,0 +1,51 @@
+module GoogleDistanceMatrix
+  class PolylineEncoder
+    # Calculates deltas between lat_lng values, internal helper class for PolylineEncoder.
+    #
+    # According to the Google's polyline encoding spec:
+    #   "Additionally, to conserve space, points only include the offset
+    #   from the previous point (except of course for the first point)"
+    #
+    # @see GoogleDistanceMatrix::PolylineEncoder
+    class Delta
+      def initialize(array_of_lat_lng_pairs, precision: 1e5)
+        @array_of_lat_lng_pairs = array_of_lat_lng_pairs
+        @precision = precision
+        @deltas = nil
+      end
+
+      def deltas
+        return @deltas if @deltas
+
+        round_to_precision
+        calculate_deltas
+
+        @deltas
+      end
+
+
+      private
+
+      def round_to_precision
+        @array_of_lat_lng_pairs.each do |pair|
+          pair[0] = (pair[0] * @precision).round
+          pair[1] = (pair[1] * @precision).round
+        end
+      end
+
+      def calculate_deltas
+        @deltas = []
+
+        delta_lat = 0
+        delta_lng = 0
+
+        @array_of_lat_lng_pairs.each do |(lat, lng)|
+          @deltas << lat - delta_lat
+          @deltas << lng - delta_lng
+
+          delta_lat, delta_lng = lat, lng
+        end
+      end
+    end
+  end
+end

--- a/lib/google_distance_matrix/polyline_encoder/value_encoder.rb
+++ b/lib/google_distance_matrix/polyline_encoder/value_encoder.rb
@@ -6,7 +6,7 @@ module GoogleDistanceMatrix
     #
     # This is an internal helper class for PolylineEncoder.
     # This encoder expects that the value is rounded.
-    # 
+    #
     # @see GoogleDistanceMatrix::PolylineEncoder
     class ValueEncoder
       def encode(value)
@@ -32,7 +32,6 @@ module GoogleDistanceMatrix
           value >>= 5
         end
 
-        # TODO See if we can make a test for this
         chunks_of_5_bits << 0 if chunks_of_5_bits.empty?
 
         # Step 8, 9 and 10: OR each value with 0x20, unless last one. Add 63 to all values

--- a/lib/google_distance_matrix/polyline_encoder/value_encoder.rb
+++ b/lib/google_distance_matrix/polyline_encoder/value_encoder.rb
@@ -1,0 +1,62 @@
+module GoogleDistanceMatrix
+  class PolylineEncoder
+    # Encodes a single value, like 17998321, in to encoded polyline value,
+    # as described in Google's documentation
+    # https://developers.google.com/maps/documentation/utilities/polylinealgorithm
+    #
+    # This is an internal helper class for PolylineEncoder.
+    # This encoder expects that the value is rounded.
+    # 
+    # @see GoogleDistanceMatrix::PolylineEncoder
+    class ValueEncoder
+      def encode(value)
+        negative = value < 0
+        value = value.abs
+
+        # Step 3: Two's complement when negative
+        value = ~value + 1 if negative
+
+        # Step 4: Left shift one bit
+        value = value << 1
+
+        # Step 5: Invert if value was negative
+        value = ~value if negative
+
+        # Step 6 and 7: 5-bit chunks in reverse order
+        # We AND 5 first bits and push them on to chunks array.
+        # Right shift bits to get rid of the ones we just put on the array.
+        # Bits will end up in reverse order.
+        chunks_of_5_bits = []
+        while value > 0 do
+          chunks_of_5_bits.push(value & 0x1f)
+          value >>= 5
+        end
+
+        # TODO See if we can make a test for this
+        chunks_of_5_bits << 0 if chunks_of_5_bits.empty?
+
+        # Step 8, 9 and 10: OR each value with 0x20, unless last one. Add 63 to all values
+        last_index = chunks_of_5_bits.length - 1
+        chunks_of_5_bits.each_with_index do |chunk, index|
+          chunks_of_5_bits[index] = chunk | 0x20 unless index == last_index
+          chunks_of_5_bits[index] += 63
+        end
+
+        # step 11: Convert to ASCII
+        chunks_of_5_bits.map(&:chr)
+      end
+
+      private
+
+      # Debug method for pretty printing integers as bits.
+      #
+      # Example of usage
+      #   p d 17998321 # => "00000001 00010010 10100001 11110001"
+      def d(v, bits = 32, chunk_size = 8)
+        (bits - 1).downto(0).
+          map { |n| v[n] }.
+          each_slice(chunk_size).map { |chunk| chunk.join }.join ' '
+      end
+    end
+  end
+end

--- a/lib/google_distance_matrix/url_builder.rb
+++ b/lib/google_distance_matrix/url_builder.rb
@@ -1,3 +1,5 @@
+require_relative 'url_builder/polyline_encoder_buffer'
+
 module GoogleDistanceMatrix
   class UrlBuilder
     BASE_URL = "maps.googleapis.com/maps/api/distancematrix/json"
@@ -48,7 +50,6 @@ module GoogleDistanceMatrix
     end
 
     def params
-
       configuration.to_param.merge(
         origins: places_to_param(matrix.origins),
         destinations: places_to_param(matrix.destinations)
@@ -59,24 +60,18 @@ module GoogleDistanceMatrix
       places_to_param_config = {lat_lng_scale: configuration.lat_lng_scale}
 
       out = []
-      encode_buffer = []
+      polyline_encode_buffer = PolylineEncoderBuffer.new
 
       places.each do |place|
         if place.lat_lng? && configuration.use_encoded_polylines
-          encode_buffer << place.lat_lng
+          polyline_encode_buffer << place.lat_lng
         else
-          if encode_buffer.any?
-            out << escape("enc:#{PolylineEncoder.encode encode_buffer}:")
-            encode_buffer.clear
-          end
+          polyline_encode_buffer.flush to: out
           out << escape(place.to_param places_to_param_config)
         end
       end
 
-      if encode_buffer.any?
-        out << escape("enc:#{PolylineEncoder.encode encode_buffer}:")
-        encode_buffer.clear
-      end
+      polyline_encode_buffer.flush to: out
 
       out.join(DELIMITER)
     end

--- a/lib/google_distance_matrix/url_builder/polyline_encoder_buffer.rb
+++ b/lib/google_distance_matrix/url_builder/polyline_encoder_buffer.rb
@@ -1,0 +1,26 @@
+module GoogleDistanceMatrix
+  class UrlBuilder
+    class PolylineEncoderBuffer
+      def initialize
+        @buffer = []
+      end
+
+      def <<(lat_lng)
+        @buffer << lat_lng
+      end
+
+      def flush(to:)
+        return if @buffer.empty?
+
+        to << escape("enc:#{PolylineEncoder.encode @buffer}:")
+        @buffer.clear
+      end
+
+      private
+
+      def escape(string)
+        CGI.escape string
+      end
+    end
+  end
+end

--- a/lib/google_distance_matrix/version.rb
+++ b/lib/google_distance_matrix/version.rb
@@ -1,3 +1,3 @@
 module GoogleDistanceMatrix
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/spec/lib/google_distance_matrix/configuration_spec.rb
+++ b/spec/lib/google_distance_matrix/configuration_spec.rb
@@ -57,6 +57,7 @@ describe GoogleDistanceMatrix::Configuration do
     it { expect(subject.avoid).to be_nil }
     it { expect(subject.units).to eq "metric" }
     it { expect(subject.lat_lng_scale).to eq 5 }
+    it { expect(subject.use_encoded_polylines).to eq false }
     it { expect(subject.protocol).to eq 'https' }
     it { expect(subject.language).to be_nil }
 

--- a/spec/lib/google_distance_matrix/polyline_encoder/delta_spec.rb
+++ b/spec/lib/google_distance_matrix/polyline_encoder/delta_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module GoogleDistanceMatrix
   describe PolylineEncoder::Delta do
     it 'calculates deltas correctly' do
-      deltas = described_class.new([[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]]).deltas
+      deltas = subject.deltas_rounded [[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]]
 
       expect(deltas).to eq [
         3850000,  -12020000,

--- a/spec/lib/google_distance_matrix/polyline_encoder/delta_spec.rb
+++ b/spec/lib/google_distance_matrix/polyline_encoder/delta_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+module GoogleDistanceMatrix
+  describe PolylineEncoder::Delta do
+    it 'calculates deltas correctly' do
+      deltas = described_class.new([[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]]).deltas
+
+      expect(deltas).to eq [
+        3850000,  -12020000,
+        220000,   -75000,
+        255200,   -550300
+      ]
+    end
+  end
+end

--- a/spec/lib/google_distance_matrix/polyline_encoder_spec.rb
+++ b/spec/lib/google_distance_matrix/polyline_encoder_spec.rb
@@ -5,6 +5,7 @@ module GoogleDistanceMatrix
     tests = {
       [[-179.9832104, -179.9832104]] => '`~oia@`~oia@',
       [[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]] => '_p~iF~ps|U_ulLnnqC_mqNvxq`@',
+      [[41.3522171071184, -86.0456299662023],[41.3522171071183, -86.0454368471533]] => 'krk{FdxdlO?e@'
     }
 
     tests.each_pair do |lat_lng_values, expected|

--- a/spec/lib/google_distance_matrix/polyline_encoder_spec.rb
+++ b/spec/lib/google_distance_matrix/polyline_encoder_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 module GoogleDistanceMatrix
   describe PolylineEncoder do
     tests = {
-      [[38.5, -120.2]] => '_p~iF~ps|U',
-      #[[38.5, -120.2], [40,7, -120.95], [43.252, -126.453]] => '_p~iF~ps|U_ulLnnqC_mqNvxq`@',
+      [[-179.9832104, -179.9832104]] => '`~oia@`~oia@',
+      [[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]] => '_p~iF~ps|U_ulLnnqC_mqNvxq`@',
     }
 
     tests.each_pair do |lat_lng_values, expected|
-      xit "encodes #{lat_lng_values} to #{expected}" do
+      it "encodes #{lat_lng_values} to #{expected}" do
         expect(described_class.encode lat_lng_values).to eq expected
       end
     end

--- a/spec/lib/google_distance_matrix/polyline_encoder_spec.rb
+++ b/spec/lib/google_distance_matrix/polyline_encoder_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+module GoogleDistanceMatrix
+  describe PolylineEncoder do
+    tests = {
+      [[38.5, -120.2]] => '_p~iF~ps|U',
+      #[[38.5, -120.2], [40,7, -120.95], [43.252, -126.453]] => '_p~iF~ps|U_ulLnnqC_mqNvxq`@',
+    }
+
+    tests.each_pair do |lat_lng_values, expected|
+      xit "encodes #{lat_lng_values} to #{expected}" do
+        expect(described_class.encode lat_lng_values).to eq expected
+      end
+    end
+  end
+end


### PR DESCRIPTION
With this pull request URL's `origins` and `destinations` values can be encoded as polylines to save space. This is particularly useful if you have a large number of origin points, because the URL is significantly shorter when using an encoded polyline.

Closes #20 