### PR TITLE
Filter sensitive logged get params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v.0.4.0 (unreleased)
 * Added option to encode origins and destinations as polylines to save characters in the URL.
+* Filter sensitive GET params when logging the URL we query Google Matrix with.
 * Dropped support for Ruby 2.0.0
 
 ## v.0.3.0

--- a/lib/google_distance_matrix.rb
+++ b/lib/google_distance_matrix.rb
@@ -19,7 +19,6 @@ require "google_distance_matrix/place"
 require "google_distance_matrix/route"
 require "google_distance_matrix/polyline_encoder"
 
-require "google_distance_matrix/log_subscriber"
 require 'google_distance_matrix/railtie' if defined? Rails
 
 
@@ -38,3 +37,5 @@ module GoogleDistanceMatrix
     @logger ||= Logger.new default_configuration.logger
   end
 end
+
+require "google_distance_matrix/log_subscriber"

--- a/lib/google_distance_matrix/configuration.rb
+++ b/lib/google_distance_matrix/configuration.rb
@@ -23,7 +23,8 @@ module GoogleDistanceMatrix
       traffic_model: "best_guess",
       use_encoded_polylines: false,
       protocol: 'https',
-      lat_lng_scale: 5
+      lat_lng_scale: 5,
+      filter_parameters_in_logged_url: ['key', 'signature'].freeze
     }.with_indifferent_access
 
     attr_accessor *ATTRIBUTES
@@ -46,6 +47,8 @@ module GoogleDistanceMatrix
 
     attr_accessor :cache, :logger
 
+    # When logging we filter sensitive parameters
+    attr_accessor :filter_parameters_in_logged_url
 
     validates :mode, inclusion: {in: ["driving", "walking", "bicycling", "transit"]}, allow_blank: true
     validates :avoid, inclusion: {in: ["tolls", "highways", "ferries", "indoor"]}, allow_blank: true
@@ -62,7 +65,7 @@ module GoogleDistanceMatrix
 
     def initialize
       API_DEFAULTS.each_pair do |attr_name, value|
-        self[attr_name] = value
+        self[attr_name] = value.dup rescue value
       end
     end
 

--- a/lib/google_distance_matrix/log_subscriber.rb
+++ b/lib/google_distance_matrix/log_subscriber.rb
@@ -18,7 +18,7 @@ module GoogleDistanceMatrix
 
     def filter_url!(url)
       config.filter_parameters_in_logged_url.each do |param|
-        url.sub! %r{(#{param})=.*?(&|$)}, '\1=[FILTERED]\2'
+        url.gsub! %r{(#{param})=.*?(&|$)}, '\1=[FILTERED]\2'
       end
 
       url

--- a/spec/lib/google_distance_matrix/log_subscriber_spec.rb
+++ b/spec/lib/google_distance_matrix/log_subscriber_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+module GoogleDistanceMatrix
+  describe LogSubscriber do
+    class MockLogger
+      attr_reader :logged
+
+      def initialize
+        @logged = []
+      end
+
+      def info(msg, tag)
+        @logged << msg
+      end
+
+      def error(msg)
+        fail msg
+      end
+    end
+
+    # Little helper to clean up examples
+    def notify(instrumentation)
+      ActiveSupport::Notifications.instrument "client_request_matrix_data.google_distance_matrix", instrumentation do
+      end
+    end
+
+
+    let(:mock_logger) { MockLogger.new }
+    let(:config) { Configuration.new }
+
+    # Attach our own test logger, re-attach the original attached log subscriber after test.
+    before do
+      @old_subscribers = LogSubscriber.subscribers.dup
+      LogSubscriber.subscribers.clear
+      LogSubscriber.attach_to "google_distance_matrix", LogSubscriber.new(logger: mock_logger, config: config)
+    end
+
+    after do
+      @old_subscribers.each do |subscriber|
+        LogSubscriber.attach_to "google_distance_matrix", subscriber
+      end
+    end
+
+
+    it "logs the url and elements" do
+      url = 'https://example.com'
+      instrumentation = {url: url, elements: 0}
+
+      expect { notify instrumentation }.to change(mock_logger.logged, :length).from(0).to 1
+
+      expect(mock_logger.logged.first).to include "(elements: 0) GET https://example.com"
+    end
+
+    describe "filtering of logged url" do
+      it "filters nothing if config has no keys to be filtered" do
+        config.filter_parameters_in_logged_url.clear
+
+        instrumentation = {url: 'https://example.com/?foo=bar&sensitive=secret'}
+        notify instrumentation
+
+        expect(mock_logger.logged.first).to include "https://example.com/?foo=bar&sensitive=secret"
+      end
+
+      it "filters sensitive GET param if config has it in list of params to filter" do
+        config.filter_parameters_in_logged_url << 'sensitive'
+
+        instrumentation = {url: 'https://example.com/?foo=bar&sensitive=secret'}
+        notify instrumentation
+
+        expect(mock_logger.logged.first).to include "https://example.com/?foo=bar&sensitive=[FILTERED]"
+      end
+
+      it "filters key and signature" do
+        instrumentation = {url: 'https://example.com/?key=bar&signature=secret&other=foo'}
+        notify instrumentation
+
+        expect(mock_logger.logged.first).to include "https://example.com/?key=[FILTERED]&signature=[FILTERED]&other=foo"
+      end
+    end
+  end
+end

--- a/spec/lib/google_distance_matrix/log_subscriber_spec.rb
+++ b/spec/lib/google_distance_matrix/log_subscriber_spec.rb
@@ -70,11 +70,18 @@ module GoogleDistanceMatrix
         expect(mock_logger.logged.first).to include "https://example.com/?foo=bar&sensitive=[FILTERED]"
       end
 
-      it "filters key and signature" do
+      it "filters key and signature as defaul from configuration" do
         instrumentation = {url: 'https://example.com/?key=bar&signature=secret&other=foo'}
         notify instrumentation
 
         expect(mock_logger.logged.first).to include "https://example.com/?key=[FILTERED]&signature=[FILTERED]&other=foo"
+      end
+
+      it "filters all appearances of a param" do
+        instrumentation = {url: 'https://example.com/?key=bar&key=secret&other=foo'}
+        notify instrumentation
+
+        expect(mock_logger.logged.first).to include "https://example.com/?key=[FILTERED]&key=[FILTERED]&other=foo"
       end
     end
   end


### PR DESCRIPTION
Filters sensitive params from URL to Google Distance Matrix before we log it. `key`, `signature` will be replaced by default.

You can override this in configuration by setting `filter_parameters_in_logged_url` to `[]`. This may be useful when you want to copy the URL and inspect raw response for debugging during development.

Fixes #25 