### PR TITLE
Fix request cache when filtering sensitive params.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## v.0.5.0
+
+This release contains breaking change where `url` has been renamed to
+`sensitive_url`. A `filtered_url` method is added to make it clear that
+the URL returned is filtered according to configuration.
 * Fixed an issue where read/write to cache used url with sensitive data and
   and filtered url resulting in cache miss.
 * Instrumentation payload `url` renamed `sensitive_url`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,16 @@
 This release contains breaking change where `url` has been renamed to
 `sensitive_url`. A `filtered_url` method is added to make it clear that
 the URL returned is filtered according to configuration.
+
+The cache key is changed so it no longer uses the URL, but a digest of the URL
+as key.
+
 * Fixed an issue where read/write to cache used url with sensitive data and
   and filtered url resulting in cache miss.
 * Instrumentation payload `url` renamed `sensitive_url`.
 * Instrumentation payload added `filtered_url`.
+* Cache key is a digest of the `sensitive_url` so we don't store in cache the
+  sensitive parts of the URL.
 
 ## v.0.4.0
 * When mode is `driving` and `departure_time` is set all `route` objects will contain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v.0.5.0
+* Fixed an issue where read/write to cache used url with sensitive data and
+  and filtered url resulting in cache miss.
+* Instrumentation payload `url` renamed `sensitive_url`.
+* Instrumentation payload added `filtered_url`.
+
 ## v.0.4.0
 * When mode is `driving` and `departure_time` is set all `route` objects will contain
   `duration_in_traffic_in_seconds` and `duration_in_traffic_text`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v.0.5.0
+## v.0.5.0 (unreleased)
 
 This release contains breaking change where `url` has been renamed to
 `sensitive_url`. A `filtered_url` method is added to make it clear that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 This release contains breaking change where `url` has been renamed to
 `sensitive_url`. A `filtered_url` method is added to make it clear that
-the URL returned is filtered according to configuration.
+the URL returned is filtered according to configuration while the other one
+will contain sensitive information like key and signature.
 
 The cache key is changed so it no longer uses the URL, but a digest of the URL
-as key.
+as key. You may set `config.cache_key_transform` to a block passing given url
+through if you don't want this.
 
 * Fixed an issue where read/write to cache used url with sensitive data and
   and filtered url resulting in cache miss.
@@ -13,6 +15,8 @@ as key.
 * Instrumentation payload added `filtered_url`.
 * Cache key is a digest of the `sensitive_url` so we don't store in cache the
   sensitive parts of the URL.
+* Digesting cache key is configurable with `cache_key_transform`. It's a callable
+  object expected to take the url and transform it to the key you want.
 
 ## v.0.4.0
 * When mode is `driving` and `departure_time` is set all `route` objects will contain

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in google_distance_matrix.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,14 @@
-require "bundler/gem_tasks"
+# frozen_string_literal: true
 
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
+
+require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |t|
-  t.rspec_opts = ["-c", "-f progress", "-r ./spec/spec_helper.rb"]
+  t.rspec_opts = ['-c', '-f progress', '-r ./spec/spec_helper.rb']
   t.pattern = 'spec/**/*_spec.rb'
 end
 
-task default: :spec
+task default: %i[rubocop spec]

--- a/google_distance_matrix.gemspec
+++ b/google_distance_matrix.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rspec', '~> 3.5.0'
+  spec.add_development_dependency 'rubocop', '~> 0.48'
   spec.add_development_dependency 'shoulda-matchers', '~> 3.1.1'
   spec.add_development_dependency 'webmock', '~> 3.0.1'
   spec.add_development_dependency 'rake'

--- a/lib/google_distance_matrix.rb
+++ b/lib/google_distance_matrix.rb
@@ -1,29 +1,31 @@
-require "google_distance_matrix/version"
+# frozen_string_literal: true
 
-require "cgi"
-require "json"
-require "active_model"
-require "active_support/core_ext/hash"
-require "google_business_api_url_signer"
+require 'google_distance_matrix/version'
 
-require "google_distance_matrix/logger"
-require "google_distance_matrix/errors"
-require "google_distance_matrix/configuration"
-require "google_distance_matrix/url_builder"
-require "google_distance_matrix/client"
-require "google_distance_matrix/client_cache"
-require "google_distance_matrix/routes_finder"
-require "google_distance_matrix/matrix"
-require "google_distance_matrix/places"
-require "google_distance_matrix/place"
-require "google_distance_matrix/route"
-require "google_distance_matrix/polyline_encoder"
+require 'cgi'
+require 'json'
+require 'active_model'
+require 'active_support/core_ext/hash'
+require 'google_business_api_url_signer'
+
+require 'google_distance_matrix/logger'
+require 'google_distance_matrix/errors'
+require 'google_distance_matrix/configuration'
+require 'google_distance_matrix/url_builder'
+require 'google_distance_matrix/client'
+require 'google_distance_matrix/client_cache'
+require 'google_distance_matrix/routes_finder'
+require 'google_distance_matrix/matrix'
+require 'google_distance_matrix/places'
+require 'google_distance_matrix/place'
+require 'google_distance_matrix/route'
+require 'google_distance_matrix/polyline_encoder'
 
 require 'google_distance_matrix/railtie' if defined? Rails
 
-
+# Main module for the GoogleDistanceMatrix
 module GoogleDistanceMatrix
-  extend self
+  module_function
 
   def default_configuration
     @default_configuration ||= Configuration.new
@@ -38,4 +40,4 @@ module GoogleDistanceMatrix
   end
 end
 
-require "google_distance_matrix/log_subscriber"
+require 'google_distance_matrix/log_subscriber'

--- a/lib/google_distance_matrix/client.rb
+++ b/lib/google_distance_matrix/client.rb
@@ -11,7 +11,16 @@ module GoogleDistanceMatrix
       UNKNOWN_ERROR
     ].freeze
 
-    def get(url, instrumentation: {})
+    # Make a GET request to given URL
+    #
+    # @param url              The URL to Google's API we'll make a request to
+    # @param instrumentation  A hash with instrumentation payload
+    # @param options          Other options we don't care about, for example we'll capture
+    #                         `configuration` option which we are not using, but the ClientCache
+    #                         is using.
+    #
+    # @return Hash with data from parsed response body
+    def get(url, instrumentation: {}, **_options)
       uri = URI.parse url
 
       response = ActiveSupport::Notifications.instrument(

--- a/lib/google_distance_matrix/client.rb
+++ b/lib/google_distance_matrix/client.rb
@@ -11,9 +11,8 @@ module GoogleDistanceMatrix
       UNKNOWN_ERROR
     ].freeze
 
-    def get(url, options = {})
+    def get(url, instrumentation: {})
       uri = URI.parse url
-      instrumentation = { url: url }.merge(options[:instrumentation] || {})
 
       response = ActiveSupport::Notifications.instrument(
         'client_request_matrix_data.google_distance_matrix', instrumentation

--- a/lib/google_distance_matrix/client_cache.rb
+++ b/lib/google_distance_matrix/client_cache.rb
@@ -1,12 +1,19 @@
 # frozen_string_literal: true
 
+require 'digest'
+
 module GoogleDistanceMatrix
   # Cached client, which takes care of caching data from Google API
   class ClientCache
     attr_reader :client, :cache
 
+    # Returns a cache key for given URL
+    #
+    # @return String
     def self.key(url)
-      url
+      digest = Digest::SHA512.new
+      digest << url
+      digest.to_s
     end
 
     def initialize(client, cache)

--- a/lib/google_distance_matrix/client_cache.rb
+++ b/lib/google_distance_matrix/client_cache.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'digest'
-
 module GoogleDistanceMatrix
   # Cached client, which takes care of caching data from Google API
   class ClientCache
@@ -10,10 +8,8 @@ module GoogleDistanceMatrix
     # Returns a cache key for given URL
     #
     # @return String
-    def self.key(url)
-      digest = Digest::SHA512.new
-      digest << url
-      digest.to_s
+    def self.key(url, config)
+      config.cache_key_transform.call url
     end
 
     def initialize(client, cache)
@@ -22,7 +18,7 @@ module GoogleDistanceMatrix
     end
 
     def get(url, options = {})
-      cache.fetch self.class.key(url) do
+      cache.fetch self.class.key(url, options.fetch(:configuration)) do
         client.get url, options
       end
     end

--- a/lib/google_distance_matrix/client_cache.rb
+++ b/lib/google_distance_matrix/client_cache.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 module GoogleDistanceMatrix
+  # Cached client, which takes care of caching data from Google API
   class ClientCache
     attr_reader :client, :cache
 

--- a/lib/google_distance_matrix/configuration.rb
+++ b/lib/google_distance_matrix/configuration.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'digest'
+
 module GoogleDistanceMatrix
   # Public: Configuration of matrix and it's request.
   #
@@ -26,7 +28,8 @@ module GoogleDistanceMatrix
       use_encoded_polylines: false,
       protocol: 'https',
       lat_lng_scale: 5,
-      filter_parameters_in_logged_url: %w[key signature].freeze
+      filter_parameters_in_logged_url: %w[key signature].freeze,
+      cache_key_transform: ->(url) { Digest::SHA512.new.update(url).to_s }
     }.with_indifferent_access
 
     attr_accessor(*ATTRIBUTES)
@@ -51,6 +54,10 @@ module GoogleDistanceMatrix
 
     # When logging we filter sensitive parameters
     attr_accessor :filter_parameters_in_logged_url
+
+    # Callable object which transform given url to key used in cache
+    # @see ClientCache
+    attr_accessor :cache_key_transform
 
     validates :mode, inclusion: { in: %w[driving walking bicycling transit] }, allow_blank: true
     validates :avoid, inclusion: { in: %w[tolls highways ferries indoor] }, allow_blank: true

--- a/lib/google_distance_matrix/errors.rb
+++ b/lib/google_distance_matrix/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GoogleDistanceMatrix
   # Public: Error class for lib.
   class Error < StandardError
@@ -67,7 +69,8 @@ module GoogleDistanceMatrix
     end
 
     def to_s
-      "GoogleDistanceMatrix::ClientError - #{[response, status_read_from_api_response].compact.join('. ')}."
+      "GoogleDistanceMatrix::ClientError - \
+        #{[response, status_read_from_api_response].compact.join('. ')}."
     end
   end
 
@@ -75,7 +78,8 @@ module GoogleDistanceMatrix
   #
   # See https://developers.google.com/maps/documentation/distancematrix/#Limits, which states:
   # "Distance Matrix API URLs are restricted to 2048 characters, before URL encoding."
-  # "As some Distance Matrix API service URLs may involve many locations, be aware of this limit when constructing your URLs."
+  # "As some Distance Matrix API service URLs may involve many locations,
+  # be aware of this limit when constructing your URLs."
   #
   class MatrixUrlTooLong < ClientError
     attr_reader :url, :max_url_size
@@ -91,5 +95,4 @@ module GoogleDistanceMatrix
       "Matrix API URL max size is: #{max_url_size}. Built URL was: #{url.length}. URL: '#{url}'."
     end
   end
-
 end

--- a/lib/google_distance_matrix/log_subscriber.rb
+++ b/lib/google_distance_matrix/log_subscriber.rb
@@ -19,19 +19,9 @@ module GoogleDistanceMatrix
     end
 
     def client_request_matrix_data(event)
-      url = filter_url! event.payload[:url]
+      url = event.payload[:filtered_url]
       logger.info "(#{event.duration}ms) (elements: #{event.payload[:elements]}) GET #{url}",
                   tag: :client
-    end
-
-    private
-
-    def filter_url!(url)
-      config.filter_parameters_in_logged_url.each do |param|
-        url = url.gsub(/(#{param})=.*?(&|$)/, '\1=[FILTERED]\2')
-      end
-
-      url
     end
   end
 end

--- a/lib/google_distance_matrix/log_subscriber.rb
+++ b/lib/google_distance_matrix/log_subscriber.rb
@@ -28,7 +28,7 @@ module GoogleDistanceMatrix
 
     def filter_url!(url)
       config.filter_parameters_in_logged_url.each do |param|
-        url.gsub! %r{(#{param})=.*?(&|$)}, '\1=[FILTERED]\2'
+        url = url.gsub(/(#{param})=.*?(&|$)/, '\1=[FILTERED]\2')
       end
 
       url

--- a/lib/google_distance_matrix/logger.rb
+++ b/lib/google_distance_matrix/logger.rb
@@ -1,7 +1,10 @@
+# frozen_string_literal: true
+
 module GoogleDistanceMatrix
+  # Logger class for Google Distance Matrix
   class Logger
-    PREFIXES = %w[google_distance_matrix]
-    LEVELS = %w[fatal error warn info debug]
+    PREFIXES = %w[google_distance_matrix].freeze
+    LEVELS = %w[fatal error warn info debug].freeze
 
     attr_reader :backend
 
@@ -20,13 +23,12 @@ module GoogleDistanceMatrix
       end
     end
 
-
     private
 
     def tag_msg(msg, tags)
       msg_buffer = tags.map { |tag| "[#{tag}]" }
       msg_buffer << msg
-      msg_buffer.join " "
+      msg_buffer.join ' '
     end
   end
 end

--- a/lib/google_distance_matrix/matrix.rb
+++ b/lib/google_distance_matrix/matrix.rb
@@ -90,7 +90,11 @@ module GoogleDistanceMatrix
     end
 
     def url
-      UrlBuilder.new(self).sensitive_url
+      url_builder.sensitive_url
+    end
+
+    def filtered_url
+      url_builder.filtered_url
     end
 
     def inspect
@@ -103,16 +107,28 @@ module GoogleDistanceMatrix
 
     private
 
+    def url_builder
+      @url_builder ||= UrlBuilder.new self
+    end
+
     def routes_finder
       @routes_finder ||= RoutesFinder.new self
     end
 
     def load_matrix
       parsed = JSON.parse(
-        client.get(url, instrumentation: { elements: origins.length * destinations.length }).body
+        client.get(url, instrumentation: instrumentation_for_api_request).body
       )
 
       create_route_objects_for_parsed_data parsed
+    end
+
+    def instrumentation_for_api_request
+      {
+        elements: origins.length * destinations.length,
+        sensitive_url: url,
+        filtered_url: filtered_url
+      }
     end
 
     def create_route_objects_for_parsed_data(parsed)

--- a/lib/google_distance_matrix/matrix.rb
+++ b/lib/google_distance_matrix/matrix.rb
@@ -57,6 +57,8 @@ module GoogleDistanceMatrix
       @configuration = attributes[:configuration] || GoogleDistanceMatrix.default_configuration.dup
     end
 
+    delegate :sensitive_url, :filtered_url, to: :url_builder
+
     delegate :route_for,  :routes_for,  to: :routes_finder
     delegate :route_for!, :routes_for!, to: :routes_finder
     delegate :shortest_route_by_distance_to,  :shortest_route_by_duration_to,   to: :routes_finder
@@ -89,14 +91,6 @@ module GoogleDistanceMatrix
       yield configuration
     end
 
-    def url
-      url_builder.sensitive_url
-    end
-
-    def filtered_url
-      url_builder.filtered_url
-    end
-
     def inspect
       attributes = %w[origins destinations]
       attributes << 'data' if loaded?
@@ -117,7 +111,7 @@ module GoogleDistanceMatrix
 
     def load_matrix
       parsed = JSON.parse(
-        client.get(url, instrumentation: instrumentation_for_api_request).body
+        client.get(sensitive_url, instrumentation: instrumentation_for_api_request).body
       )
 
       create_route_objects_for_parsed_data parsed
@@ -126,7 +120,7 @@ module GoogleDistanceMatrix
     def instrumentation_for_api_request
       {
         elements: origins.length * destinations.length,
-        sensitive_url: url,
+        sensitive_url: sensitive_url,
         filtered_url: filtered_url
       }
     end
@@ -157,7 +151,7 @@ module GoogleDistanceMatrix
     def clear_from_cache!
       return if configuration.cache.nil?
 
-      configuration.cache.delete ClientCache.key(url)
+      configuration.cache.delete ClientCache.key(sensitive_url)
     end
   end
 end

--- a/lib/google_distance_matrix/matrix.rb
+++ b/lib/google_distance_matrix/matrix.rb
@@ -90,7 +90,7 @@ module GoogleDistanceMatrix
     end
 
     def url
-      UrlBuilder.new(self).url
+      UrlBuilder.new(self).sensitive_url
     end
 
     def inspect

--- a/lib/google_distance_matrix/matrix.rb
+++ b/lib/google_distance_matrix/matrix.rb
@@ -102,7 +102,11 @@ module GoogleDistanceMatrix
     private
 
     def url_builder
-      @url_builder ||= UrlBuilder.new self
+      # We do not keep url builder as an instance variable as origins and destinations
+      # may be added after URL is being built for the first time. We should either
+      # make our matrix immutable or reset if origins/destinations are added after data (and
+      # the url) first being built and data fetched.
+      UrlBuilder.new self
     end
 
     def routes_finder

--- a/lib/google_distance_matrix/matrix.rb
+++ b/lib/google_distance_matrix/matrix.rb
@@ -110,10 +110,13 @@ module GoogleDistanceMatrix
     end
 
     def load_matrix
-      parsed = JSON.parse(
-        client.get(sensitive_url, instrumentation: instrumentation_for_api_request).body
-      )
+      body = client.get(
+        sensitive_url,
+        instrumentation: instrumentation_for_api_request,
+        configuration: configuration
+      ).body
 
+      parsed = JSON.parse(body)
       create_route_objects_for_parsed_data parsed
     end
 
@@ -151,7 +154,7 @@ module GoogleDistanceMatrix
     def clear_from_cache!
       return if configuration.cache.nil?
 
-      configuration.cache.delete ClientCache.key(sensitive_url)
+      configuration.cache.delete ClientCache.key(sensitive_url, configuration)
     end
   end
 end

--- a/lib/google_distance_matrix/places.rb
+++ b/lib/google_distance_matrix/places.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 module GoogleDistanceMatrix
+  # Represents a collection of places
   class Places
     include Enumerable
 
@@ -7,10 +10,9 @@ module GoogleDistanceMatrix
       concat Array.wrap(places)
     end
 
-
     delegate :each, :[], :length, :index, :pop, :shift, :delete_at, :compact, :inspect, to: :places
 
-    [:<<, :push, :unshift].each do |method|
+    %i[<< push unshift].each do |method|
       define_method method do |*args|
         args = ensure_args_are_places args
 
@@ -22,9 +24,8 @@ module GoogleDistanceMatrix
     end
 
     def concat(other)
-      push *other
+      push(*other)
     end
-
 
     private
 

--- a/lib/google_distance_matrix/polyline_encoder.rb
+++ b/lib/google_distance_matrix/polyline_encoder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'polyline_encoder/delta'
 require_relative 'polyline_encoder/value_encoder'
 
@@ -7,7 +9,6 @@ module GoogleDistanceMatrix
   #
   # See https://developers.google.com/maps/documentation/utilities/polylinealgorithm
   class PolylineEncoder
-
     # Encodes a set of lat/lng pairs
     #
     # Example
@@ -15,7 +16,6 @@ module GoogleDistanceMatrix
     def self.encode(array_of_lat_lng_pairs)
       new(array_of_lat_lng_pairs).encode
     end
-
 
     # Initialize a new encoder
     #

--- a/lib/google_distance_matrix/polyline_encoder/delta.rb
+++ b/lib/google_distance_matrix/polyline_encoder/delta.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GoogleDistanceMatrix
   class PolylineEncoder
     # Calculates deltas between lat_lng values, internal helper class for PolylineEncoder.
@@ -20,7 +22,6 @@ module GoogleDistanceMatrix
         calculate_deltas rounded
       end
 
-
       private
 
       def round_to_precision(array_of_lat_lng_pairs)
@@ -42,7 +43,8 @@ module GoogleDistanceMatrix
           deltas << lat - delta_lat
           deltas << lng - delta_lng
 
-          delta_lat, delta_lng = lat, lng
+          delta_lat = lat
+          delta_lng = lng
         end
 
         deltas

--- a/lib/google_distance_matrix/polyline_encoder/value_encoder.rb
+++ b/lib/google_distance_matrix/polyline_encoder/value_encoder.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Style/NumericPredicate
 module GoogleDistanceMatrix
   class PolylineEncoder
     # Encodes a single value, like 17998321, in to encoded polyline value,
@@ -14,7 +15,7 @@ module GoogleDistanceMatrix
       # rubocop:disable Metrics/MethodLength
       # rubocop:disable Metrics/AbcSize
       def encode(value)
-        negative = value.negative?
+        negative = value < 0
         value = value.abs
 
         # Step 3: Two's complement when negative
@@ -31,7 +32,7 @@ module GoogleDistanceMatrix
         # Right shift bits to get rid of the ones we just put on the array.
         # Bits will end up in reverse order.
         chunks_of_5_bits = []
-        while value.positive?
+        while value > 0
           chunks_of_5_bits.push(value & 0x1f)
           value >>= 5
         end

--- a/lib/google_distance_matrix/polyline_encoder/value_encoder.rb
+++ b/lib/google_distance_matrix/polyline_encoder/value_encoder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GoogleDistanceMatrix
   class PolylineEncoder
     # Encodes a single value, like 17998321, in to encoded polyline value,
@@ -9,8 +11,10 @@ module GoogleDistanceMatrix
     #
     # @see GoogleDistanceMatrix::PolylineEncoder
     class ValueEncoder
+      # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/AbcSize
       def encode(value)
-        negative = value < 0
+        negative = value.negative?
         value = value.abs
 
         # Step 3: Two's complement when negative
@@ -27,7 +31,7 @@ module GoogleDistanceMatrix
         # Right shift bits to get rid of the ones we just put on the array.
         # Bits will end up in reverse order.
         chunks_of_5_bits = []
-        while value > 0 do
+        while value.positive?
           chunks_of_5_bits.push(value & 0x1f)
           value >>= 5
         end
@@ -44,6 +48,8 @@ module GoogleDistanceMatrix
         # step 11: Convert to ASCII
         chunks_of_5_bits.map(&:chr)
       end
+      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/AbcSize
 
       private
 
@@ -52,9 +58,9 @@ module GoogleDistanceMatrix
       # Example of usage
       #   p d 17998321 # => "00000001 00010010 10100001 11110001"
       def d(v, bits = 32, chunk_size = 8)
-        (bits - 1).downto(0).
-          map { |n| v[n] }.
-          each_slice(chunk_size).map { |chunk| chunk.join }.join ' '
+        (bits - 1).downto(0)
+                  .map { |n| v[n] }
+                  .each_slice(chunk_size).map(&:join).join ' '
       end
     end
   end

--- a/lib/google_distance_matrix/railtie.rb
+++ b/lib/google_distance_matrix/railtie.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 module GoogleDistanceMatrix
+  # Class integrating with rails
   class Railtie < Rails::Railtie
-    initializer "google_distance_matrix.logger_setup" do
+    initializer 'google_distance_matrix.logger_setup' do
       GoogleDistanceMatrix.configure_defaults do |config|
         config.logger = Rails.logger
       end

--- a/lib/google_distance_matrix/route.rb
+++ b/lib/google_distance_matrix/route.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GoogleDistanceMatrix
   # Public: Thin wrapper class for an element in the matrix.
   #
@@ -15,10 +17,9 @@ module GoogleDistanceMatrix
       duration_in_traffic_text duration_in_traffic_in_seconds
     ].freeze
 
-    attr_reader *ATTRIBUTES
+    attr_reader(*ATTRIBUTES)
 
-    delegate *(STATUSES.map { |s| s + '?' }), to: :status, allow_nil: true
-
+    delegate(*(STATUSES.map { |s| s + '?' }), to: :status, allow_nil: true)
 
     def initialize(attributes = {})
       attributes = attributes.with_indifferent_access
@@ -28,25 +29,31 @@ module GoogleDistanceMatrix
 
       @status = ActiveSupport::StringInquirer.new attributes[:status].downcase
 
-      if ok?
-        @distance_text = attributes[:distance][:text]
-        @distance_in_meters = attributes[:distance][:value]
-        @duration_text = attributes[:duration][:text]
-        @duration_in_seconds = attributes[:duration][:value]
-
-        if attributes.key? :duration_in_traffic
-          @duration_in_traffic_text = attributes[:duration_in_traffic][:text]
-          @duration_in_traffic_in_seconds = attributes[:duration_in_traffic][:value]
-        end
-      end
+      assign attributes if ok?
     end
 
-
-
     def inspect
-      inspection = ATTRIBUTES.reject { |a| public_send(a).blank? }.map { |a| "#{a}: #{public_send(a).inspect}" }.join ', '
+      attrs = ATTRIBUTES.reject do |a|
+        public_send(a).blank?
+      end
+
+      inspection = attrs.map { |a| "#{a}: #{public_send(a).inspect}" }.join ', '
 
       "#<#{self.class} #{inspection}>"
+    end
+
+    private
+
+    def assign(attributes)
+      @distance_text = attributes[:distance][:text]
+      @distance_in_meters = attributes[:distance][:value]
+      @duration_text = attributes[:duration][:text]
+      @duration_in_seconds = attributes[:duration][:value]
+
+      return unless  attributes.key? :duration_in_traffic
+
+      @duration_in_traffic_text = attributes[:duration_in_traffic][:text]
+      @duration_in_traffic_in_seconds = attributes[:duration_in_traffic][:value]
     end
   end
 end

--- a/lib/google_distance_matrix/routes_finder.rb
+++ b/lib/google_distance_matrix/routes_finder.rb
@@ -1,18 +1,15 @@
+# frozen_string_literal: true
+
 module GoogleDistanceMatrix
   # Public: Has logic for doing finder operations on a matrix.
   class RoutesFinder
-
     attr_reader :matrix
     delegate :data, :origins, :destinations, :configuration, to: :matrix
 
-
     def initialize(matrix)
       @matrix = matrix
-    end
+    end # Public: Finds routes for given place.
 
-
-
-    # Public: Finds routes for given place.
     #
     # place   -  Either an origin or destination, or an object which you built the place from
     #
@@ -25,7 +22,7 @@ module GoogleDistanceMatrix
       elsif destinations.include? place
         routes_for_destination place
       else
-        fail ArgumentError, "Given place not an origin nor destination."
+        raise ArgumentError, 'Given place not an origin nor destination.'
       end
     end
 
@@ -41,11 +38,11 @@ module GoogleDistanceMatrix
       end
     end
 
-
     # Public: Finds a route for you based on one origin and destination
     #
     # origin        - A place representing the origin, or an object which you built the origin from
-    # destination   - A place representing the destination, or an object which you built the destination from
+    # destination   - A place representing the destination, or an object which you built the
+    #                   destination from
     #
     # A Route for given origin and destination
     def route_for(options = {})
@@ -55,7 +52,7 @@ module GoogleDistanceMatrix
       destination = ensure_place options[:destination]
 
       if origin.nil? || destination.nil?
-        fail ArgumentError, "Must provide origin and destination"
+        raise ArgumentError, 'Must provide origin and destination'
       end
 
       routes_for(origin).detect { |route| route.destination == destination }
@@ -71,7 +68,6 @@ module GoogleDistanceMatrix
       end
     end
 
-
     # Public: Finds shortes route by distance to a place.
     #
     # place - The place, or object place was built from, you want the shortest route to
@@ -79,7 +75,7 @@ module GoogleDistanceMatrix
     # Returns shortest route, or nil if no routes had status ok
     def shortest_route_by_distance_to(place_or_object_place_was_built_from)
       routes = routes_for place_or_object_place_was_built_from
-      select_ok_routes(routes).min_by &:distance_in_meters
+      select_ok_routes(routes).min_by(&:distance_in_meters)
     end
 
     # Public: Finds shortes route by distance to a place.
@@ -88,7 +84,7 @@ module GoogleDistanceMatrix
     #
     # Returns shortest route, fails if any of the routes are not ok
     def shortest_route_by_distance_to!(place_or_object_place_was_built_from)
-      routes_for!(place_or_object_place_was_built_from).min_by &:distance_in_meters
+      routes_for!(place_or_object_place_was_built_from).min_by(&:distance_in_meters)
     end
 
     # Public: Finds shortes route by duration to a place.
@@ -98,7 +94,7 @@ module GoogleDistanceMatrix
     # Returns shortest route, or nil if no routes had status ok
     def shortest_route_by_duration_to(place_or_object_place_was_built_from)
       routes = routes_for place_or_object_place_was_built_from
-      select_ok_routes(routes).min_by &:duration_in_seconds
+      select_ok_routes(routes).min_by(&:duration_in_seconds)
     end
 
     # Public: Finds shortes route by duration to a place.
@@ -107,7 +103,7 @@ module GoogleDistanceMatrix
     #
     # Returns shortest route, fails if any of the routes are not ok
     def shortest_route_by_duration_to!(place_or_object_place_was_built_from)
-      routes_for!(place_or_object_place_was_built_from).min_by &:duration_in_seconds
+      routes_for!(place_or_object_place_was_built_from).min_by(&:duration_in_seconds)
     end
 
     # Public: Finds shortes route by duration in traffic to a place.
@@ -122,7 +118,7 @@ module GoogleDistanceMatrix
       ensure_driving_and_departure_time_or_fail!
 
       routes = routes_for place_or_object_place_was_built_from
-      select_ok_routes(routes).min_by &:duration_in_traffic_in_seconds
+      select_ok_routes(routes).min_by(&:duration_in_traffic_in_seconds)
     end
 
     # Public: Finds shortes route by duration in traffic to a place.
@@ -136,10 +132,8 @@ module GoogleDistanceMatrix
     def shortest_route_by_duration_in_traffic_to!(place_or_object_place_was_built_from)
       ensure_driving_and_departure_time_or_fail!
 
-      routes_for!(place_or_object_place_was_built_from).min_by &:duration_in_traffic_in_seconds
+      routes_for!(place_or_object_place_was_built_from).min_by(&:duration_in_traffic_in_seconds)
     end
-
-
 
     private
 
@@ -148,27 +142,27 @@ module GoogleDistanceMatrix
         object
       else
         find_place_for_object(origins, object) ||
-        find_place_for_object(destinations, object)
+          find_place_for_object(destinations, object)
       end
     end
 
     def find_place_for_object(collection, object)
       collection.detect do |place|
         place.extracted_attributes_from.present? &&
-        place.extracted_attributes_from == object
+          place.extracted_attributes_from == object
       end
     end
 
     def routes_for_origin(origin)
       index = origins.index origin
-      fail ArgumentError, "Given origin is not i matrix."if index.nil?
+      raise ArgumentError, 'Given origin is not i matrix.' if index.nil?
 
       data[index]
     end
 
     def routes_for_destination(destination)
       index = destinations.index destination
-      fail ArgumentError, "Given destination is not i matrix." if index.nil?
+      raise ArgumentError, 'Given destination is not i matrix.' if index.nil?
 
       [].tap do |routes|
         data.each { |row| routes << row[index] }
@@ -180,24 +174,24 @@ module GoogleDistanceMatrix
       destination_index = destinations.index destination
 
       if origin_index.nil? || destination_index.nil?
-        fail ArgumentError, "Given origin or destination is not i matrix."
+        raise ArgumentError, 'Given origin or destination is not i matrix.'
       end
 
       [data[origin_index][destination_index]]
     end
 
     def fail_unless_route_is_ok(route)
-      fail InvalidRoute.new route unless route.ok?
+      raise InvalidRoute, route unless route.ok?
     end
 
     def select_ok_routes(routes)
-      routes.select &:ok?
+      routes.select(&:ok?)
     end
 
     def ensure_driving_and_departure_time_or_fail!
-      if configuration.mode != 'driving' || configuration.departure_time.nil?
-        fail InvalidQuery, "Matrix must be in mode driving and a departure_time must be set"
-      end
+      return if configuration.mode == 'driving' && configuration.departure_time.present?
+
+      raise InvalidQuery, 'Matrix must be in mode driving and a departure_time must be set'
     end
   end
 end

--- a/lib/google_distance_matrix/routes_finder.rb
+++ b/lib/google_distance_matrix/routes_finder.rb
@@ -2,6 +2,8 @@
 
 module GoogleDistanceMatrix
   # Public: Has logic for doing finder operations on a matrix.
+  #
+  # rubocop:disable Metrics/ClassLength
   class RoutesFinder
     attr_reader :matrix
     delegate :data, :origins, :destinations, :configuration, to: :matrix

--- a/lib/google_distance_matrix/url_builder.rb
+++ b/lib/google_distance_matrix/url_builder.rb
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
 require_relative 'url_builder/polyline_encoder_buffer'
 
 module GoogleDistanceMatrix
+  # Takes care of building the url for given matrix
   class UrlBuilder
-    BASE_URL = "maps.googleapis.com/maps/api/distancematrix/json"
-    DELIMITER = CGI.escape("|")
+    BASE_URL = 'maps.googleapis.com/maps/api/distancematrix/json'
+    DELIMITER = CGI.escape('|')
     MAX_URL_SIZE = 2048
 
     attr_reader :matrix
@@ -12,41 +15,40 @@ module GoogleDistanceMatrix
     def initialize(matrix)
       @matrix = matrix
 
-      fail InvalidMatrix.new matrix if matrix.invalid?
+      raise InvalidMatrix, matrix if matrix.invalid?
     end
 
     def url
       @url ||= build_url
     end
 
-
     private
 
     def build_url
-      url = [protocol, BASE_URL, "?", get_params_string].join
+      url = [protocol, BASE_URL, '?', query_params_string].join
 
       if sign_url?
-        url = GoogleBusinessApiUrlSigner.add_signature(url, configuration.google_business_api_private_key)
+        url = GoogleBusinessApiUrlSigner.add_signature(
+          url, configuration.google_business_api_private_key
+        )
       end
 
-      if url.length > MAX_URL_SIZE
-        fail MatrixUrlTooLong.new url, MAX_URL_SIZE
-      end
+      raise MatrixUrlTooLong.new url, MAX_URL_SIZE if url.length > MAX_URL_SIZE
 
       url
     end
 
     def sign_url?
-      configuration.google_business_api_client_id.present? and
-      configuration.google_business_api_private_key.present?
+      configuration.google_business_api_client_id.present? &&
+        configuration.google_business_api_private_key.present?
     end
 
     def include_api_key?
       configuration.google_api_key.present?
     end
 
-    def get_params_string
-      params.to_a.map { |key_value| key_value.join("=") }.join("&")
+    def query_params_string
+      params.to_a.map { |key_value| key_value.join('=') }.join('&')
     end
 
     def params
@@ -56,8 +58,10 @@ module GoogleDistanceMatrix
       )
     end
 
+    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
     def places_to_param(places)
-      places_to_param_config = {lat_lng_scale: configuration.lat_lng_scale}
+      places_to_param_config = { lat_lng_scale: configuration.lat_lng_scale }
 
       out = []
       polyline_encode_buffer = PolylineEncoderBuffer.new
@@ -67,7 +71,7 @@ module GoogleDistanceMatrix
           polyline_encode_buffer << place.lat_lng
         else
           polyline_encode_buffer.flush to: out
-          out << escape(place.to_param places_to_param_config)
+          out << escape(place.to_param(places_to_param_config))
         end
       end
 
@@ -75,9 +79,11 @@ module GoogleDistanceMatrix
 
       out.join(DELIMITER)
     end
+    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
 
     def protocol
-      configuration.protocol + "://"
+      configuration.protocol + '://'
     end
 
     def escape(string)

--- a/lib/google_distance_matrix/url_builder.rb
+++ b/lib/google_distance_matrix/url_builder.rb
@@ -18,8 +18,22 @@ module GoogleDistanceMatrix
       raise InvalidMatrix, matrix if matrix.invalid?
     end
 
-    def url
+    # Returns the URL we'll call Google API with
+    #
+    # This URL contains key and signature and is therefor
+    # sensitive.
+    #
+    # @return String
+    # @see filtered_url
+    def sensitive_url
       @url ||= build_url
+    end
+
+    # Returns the URL filtered as the configuration of the matrix dictates
+    #
+    # @return String
+    def filtered_url
+      raise 'Not implemented yet'
     end
 
     private

--- a/lib/google_distance_matrix/url_builder.rb
+++ b/lib/google_distance_matrix/url_builder.rb
@@ -26,14 +26,14 @@ module GoogleDistanceMatrix
     # @return String
     # @see filtered_url
     def sensitive_url
-      @url ||= build_url
+      @sensitive_url ||= build_url
     end
 
     # Returns the URL filtered as the configuration of the matrix dictates
     #
     # @return String
     def filtered_url
-      raise 'Not implemented yet'
+      filter_url sensitive_url
     end
 
     private
@@ -48,6 +48,14 @@ module GoogleDistanceMatrix
       end
 
       raise MatrixUrlTooLong.new url, MAX_URL_SIZE if url.length > MAX_URL_SIZE
+
+      url
+    end
+
+    def filter_url(url)
+      configuration.filter_parameters_in_logged_url.each do |param|
+        url = url.gsub(/(#{param})=.*?(&|$)/, '\1=[FILTERED]\2')
+      end
 
       url
     end

--- a/lib/google_distance_matrix/url_builder/polyline_encoder_buffer.rb
+++ b/lib/google_distance_matrix/url_builder/polyline_encoder_buffer.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 module GoogleDistanceMatrix
   class UrlBuilder
+    # A buffer to contain Polyline Encoder
     class PolylineEncoderBuffer
       def initialize
         @buffer = []

--- a/lib/google_distance_matrix/version.rb
+++ b/lib/google_distance_matrix/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GoogleDistanceMatrix
-  VERSION = "0.4.0"
+  VERSION = '0.4.0'
 end

--- a/lib/google_distance_matrix/version.rb
+++ b/lib/google_distance_matrix/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GoogleDistanceMatrix
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end

--- a/spec/lib/google_distance_matrix/client_cache_spec.rb
+++ b/spec/lib/google_distance_matrix/client_cache_spec.rb
@@ -1,8 +1,11 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe GoogleDistanceMatrix::ClientCache do
+  let(:config) { GoogleDistanceMatrix::Configuration.new }
   let(:url) { 'http://www.example.com' }
-  let(:options) { { hello: :options } }
+  let(:options) { { hello: :options, configuration: config } }
 
   let(:client) { double get: 'data' }
   let(:cache) { double }
@@ -12,7 +15,7 @@ describe GoogleDistanceMatrix::ClientCache do
   # rubocop:disable Metrics/LineLength
   describe '::key' do
     it 'returns a digest of given URL' do
-      key = described_class.key 'some url with secret parts'
+      key = described_class.key 'some url with secret parts', config
       expect(key).to eq 'e90595434d4e321da6b01d2b99d77419ddaa8861d83c5971c4a119ee76bb80a7003915cc16e6966615f205b4a1d5411bb5d4a0d907f611b3fe4cc8d9049f4f9c'
     end
   end

--- a/spec/lib/google_distance_matrix/client_cache_spec.rb
+++ b/spec/lib/google_distance_matrix/client_cache_spec.rb
@@ -9,9 +9,21 @@ describe GoogleDistanceMatrix::ClientCache do
 
   subject { described_class.new client, cache }
 
+  # rubocop:disable Metrics/LineLength
+  describe '::key' do
+    it 'returns a digest of given URL' do
+      key = described_class.key 'some url with secret parts'
+      expect(key).to eq 'e90595434d4e321da6b01d2b99d77419ddaa8861d83c5971c4a119ee76bb80a7003915cc16e6966615f205b4a1d5411bb5d4a0d907f611b3fe4cc8d9049f4f9c'
+    end
+  end
+
   describe '#get' do
     it 'returns from cache if it hits' do
-      expect(cache).to receive(:fetch).with(url).and_return 'cached-data'
+      expect(cache)
+        .to receive(:fetch)
+        .with('2f7d4c4d8a51afd0f9efb9edfda07591591cccc3704130328ad323d3cb5bf7ff19df5e895b402c99217d27d5f4547618094d47069c9ba58370ed8e26cc1de114')
+        .and_return 'cached-data'
+
       expect(subject.get(url, options)).to eq 'cached-data'
     end
 

--- a/spec/lib/google_distance_matrix/client_spec.rb
+++ b/spec/lib/google_distance_matrix/client_spec.rb
@@ -1,66 +1,76 @@
-require "spec_helper"
+# frozen_string_literal: true
+
+require 'spec_helper'
 
 describe GoogleDistanceMatrix::Client, :request_recordings do
-  let(:origin_1) { GoogleDistanceMatrix::Place.new address: "Karl Johans gate, Oslo" }
-  let(:destination_1) { GoogleDistanceMatrix::Place.new address: "Drammensveien 1, Oslo" }
-  let(:matrix) { GoogleDistanceMatrix::Matrix.new(origins: [origin_1], destinations: [destination_1]) }
+  let(:origin_1) { GoogleDistanceMatrix::Place.new address: 'Karl Johans gate, Oslo' }
+  let(:destination_1) { GoogleDistanceMatrix::Place.new address: 'Drammensveien 1, Oslo' }
+  let(:matrix) do
+    GoogleDistanceMatrix::Matrix.new(origins: [origin_1], destinations: [destination_1])
+  end
 
   let(:url_builder) { GoogleDistanceMatrix::UrlBuilder.new matrix }
-  let(:url) { url_builder.url }
+  let(:url) { url_builder.sensitive_url }
 
   subject { GoogleDistanceMatrix::Client.new }
 
-  describe "success" do
+  describe 'success' do
     before { stub_request(:get, url).to_return body: recorded_request_for(:success) }
 
-    it "makes the request" do
-      expect(subject.get(url_builder.url).body).to eq recorded_request_for(:success).read
+    it 'makes the request' do
+      expect(subject.get(url_builder.sensitive_url).body).to eq recorded_request_for(:success).read
     end
   end
 
-  describe "client errors" do
-    describe "server issues 4xx client error" do
-      it "wraps the error http response" do
-        stub_request(:get, url).to_return status: [400, "Client error"]
-        expect { subject.get(url_builder.url) }.to raise_error GoogleDistanceMatrix::ClientError
+  describe 'client errors' do
+    describe 'server issues 4xx client error' do
+      it 'wraps the error http response' do
+        stub_request(:get, url).to_return status: [400, 'Client error']
+        expect { subject.get(url_builder.sensitive_url) }
+          .to raise_error GoogleDistanceMatrix::ClientError
       end
 
-      it "wraps uri too long error" do
-        stub_request(:get, url).to_return status: [414, "Client error"]
-        expect { subject.get(url_builder.url) }.to raise_error GoogleDistanceMatrix::MatrixUrlTooLong
+      it 'wraps uri too long error' do
+        stub_request(:get, url).to_return status: [414, 'Client error']
+        expect { subject.get(url_builder.sensitive_url) }
+          .to raise_error GoogleDistanceMatrix::MatrixUrlTooLong
       end
     end
 
     described_class::CLIENT_ERRORS.each do |error|
       it "wraps '#{error}' client error" do
-        stub_request(:get, url).to_return body: JSON.generate({status: error})
-        expect { subject.get(url_builder.url) }.to raise_error GoogleDistanceMatrix::ClientError
+        stub_request(:get, url).to_return body: JSON.generate(status: error)
+        expect { subject.get(url_builder.sensitive_url) }
+          .to raise_error GoogleDistanceMatrix::ClientError
       end
     end
   end
 
-  describe "request errors" do
-    describe "server error" do
-      before { stub_request(:get, url).to_return status: [500, "Internal Server Error"] }
+  describe 'request errors' do
+    describe 'server error' do
+      before { stub_request(:get, url).to_return status: [500, 'Internal Server Error'] }
 
-      it "wraps the error http response" do
-        expect { subject.get(url_builder.url) }.to raise_error GoogleDistanceMatrix::ServerError
+      it 'wraps the error http response' do
+        expect { subject.get(url_builder.sensitive_url) }
+          .to raise_error GoogleDistanceMatrix::ServerError
       end
     end
 
-    describe "timeout" do
+    describe 'timeout' do
       before { stub_request(:get, url).to_timeout }
 
-      it "wraps the error from Net::HTTP" do
-        expect { subject.get(url_builder.url).body }.to raise_error GoogleDistanceMatrix::ServerError
+      it 'wraps the error from Net::HTTP' do
+        expect { subject.get(url_builder.sensitive_url).body }
+          .to raise_error GoogleDistanceMatrix::ServerError
       end
     end
 
-    describe "server error" do
-      before { stub_request(:get, url).to_return status: [999, "Unknown"] }
+    describe 'server error' do
+      before { stub_request(:get, url).to_return status: [999, 'Unknown'] }
 
-      it "wraps the error http response" do
-        expect { subject.get(url_builder.url) }.to raise_error GoogleDistanceMatrix::ServerError
+      it 'wraps the error http response' do
+        expect { subject.get(url_builder.sensitive_url) }
+          .to raise_error GoogleDistanceMatrix::ServerError
       end
     end
   end

--- a/spec/lib/google_distance_matrix/configuration_spec.rb
+++ b/spec/lib/google_distance_matrix/configuration_spec.rb
@@ -1,11 +1,13 @@
-require "spec_helper"
+# frozen_string_literal: true
+
+require 'spec_helper'
 
 describe GoogleDistanceMatrix::Configuration do
   include Shoulda::Matchers::ActiveModel
 
   subject { described_class.new }
 
-  describe "Validations" do
+  describe 'Validations' do
     describe 'departure_time' do
       it 'is valid with a timestamp' do
         subject.departure_time = Time.now.to_i
@@ -46,28 +48,32 @@ describe GoogleDistanceMatrix::Configuration do
       end
     end
 
-    it { should validate_inclusion_of(:mode).in_array(["driving", "walking", "bicycling", "transit"]) }
+    it { should validate_inclusion_of(:mode).in_array(%w[driving walking bicycling transit]) }
     it { should allow_value(nil).for(:mode) }
 
-    it { should validate_inclusion_of(:avoid).in_array(["tolls", "highways", "ferries", "indoor"]) }
+    it { should validate_inclusion_of(:avoid).in_array(%w[tolls highways ferries indoor]) }
     it { should allow_value(nil).for(:avoid) }
 
-    it { should validate_inclusion_of(:units).in_array(["metric", "imperial"]) }
+    it { should validate_inclusion_of(:units).in_array(%w[metric imperial]) }
     it { should allow_value(nil).for(:units) }
 
+    it { should validate_inclusion_of(:protocol).in_array(%w[http https]) }
 
-    it { should validate_inclusion_of(:protocol).in_array(["http", "https"]) }
-
-    it { should validate_inclusion_of(:transit_mode).in_array(["bus", "subway", "train", "tram", "rail"])}
-    it { should validate_inclusion_of(:transit_routing_preference).in_array(["less_walking",  "fewer_transfers"])}
-    it { should validate_inclusion_of(:traffic_model).in_array(["best_guess", "pessimistic", "optimistic"])}
+    it { should validate_inclusion_of(:transit_mode).in_array(%w[bus subway train tram rail]) }
+    it {
+      should validate_inclusion_of(
+        :transit_routing_preference
+      ).in_array(%w[less_walking fewer_transfers])
+    }
+    it {
+      should validate_inclusion_of(:traffic_model).in_array(%w[best_guess pessimistic optimistic])
+    }
   end
 
-
-  describe "defaults" do
-    it { expect(subject.mode).to eq "driving" }
+  describe 'defaults' do
+    it { expect(subject.mode).to eq 'driving' }
     it { expect(subject.avoid).to be_nil }
-    it { expect(subject.units).to eq "metric" }
+    it { expect(subject.units).to eq 'metric' }
     it { expect(subject.lat_lng_scale).to eq 5 }
     it { expect(subject.use_encoded_polylines).to eq false }
     it { expect(subject.protocol).to eq 'https' }
@@ -84,13 +90,12 @@ describe GoogleDistanceMatrix::Configuration do
 
     it { expect(subject.logger).to be_nil }
     it { expect(subject.cache).to be_nil }
-  end
 
 
-  describe "#to_param" do
+  describe '#to_param' do
     described_class::ATTRIBUTES.each do |attr|
       it "includes #{attr}" do
-        subject[attr] = "foo"
+        subject[attr] = 'foo'
         expect(subject.to_param[attr]).to eq subject.public_send(attr)
       end
 
@@ -108,14 +113,14 @@ describe GoogleDistanceMatrix::Configuration do
       end
     end
 
-    it "includes client if google_business_api_client_id has been set" do
-      subject.google_business_api_client_id = "123"
-      expect(subject.to_param['client']).to eq "123"
+    it 'includes client if google_business_api_client_id has been set' do
+      subject.google_business_api_client_id = '123'
+      expect(subject.to_param['client']).to eq '123'
     end
 
-    it "includes key if google_api_key has been set" do
-      subject.google_api_key = "12345"
-      expect(subject.to_param['key']).to eq("12345")
+    it 'includes key if google_api_key has been set' do
+      subject.google_api_key = '12345'
+      expect(subject.to_param['key']).to eq('12345')
     end
   end
 end

--- a/spec/lib/google_distance_matrix/configuration_spec.rb
+++ b/spec/lib/google_distance_matrix/configuration_spec.rb
@@ -91,6 +91,13 @@ describe GoogleDistanceMatrix::Configuration do
     it { expect(subject.logger).to be_nil }
     it { expect(subject.cache).to be_nil }
 
+    # rubocop:disable Metrics/LineLength
+    it 'has a default expected cache_key_transform' do
+      key = subject.cache_key_transform.call('foo')
+      expect(key).to eq 'f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7'
+    end
+    # rubocop:enable Metrics/LineLength
+  end
 
   describe '#to_param' do
     described_class::ATTRIBUTES.each do |attr|

--- a/spec/lib/google_distance_matrix/log_subscriber_spec.rb
+++ b/spec/lib/google_distance_matrix/log_subscriber_spec.rb
@@ -73,6 +73,16 @@ module GoogleDistanceMatrix
         expect(mock_logger.logged.first).to include 'https://example.com/?foo=bar&sensitive=[FILTERED]'
       end
 
+      it 'filter sensitive GET param does not mutate the url' do
+        config.filter_parameters_in_logged_url << 'sensitive'
+        url = 'https://example.com/?foo=bar&sensitive=secret'
+
+        instrumentation = { url: url }
+        notify instrumentation
+
+        expect(url).to eq 'https://example.com/?foo=bar&sensitive=secret'
+      end
+
       it 'filters key and signature as defaul from configuration' do
         instrumentation = { url: 'https://example.com/?key=bar&signature=secret&other=foo' }
         notify instrumentation

--- a/spec/lib/google_distance_matrix/log_subscriber_spec.rb
+++ b/spec/lib/google_distance_matrix/log_subscriber_spec.rb
@@ -47,55 +47,11 @@ module GoogleDistanceMatrix
 
     it 'logs the url and elements' do
       url = 'https://example.com'
-      instrumentation = { url: url, elements: 0 }
+      instrumentation = { filtered_url: url, elements: 0 }
 
       expect { notify instrumentation }.to change(mock_logger.logged, :length).from(0).to 1
 
       expect(mock_logger.logged.first).to include '(elements: 0) GET https://example.com'
-    end
-
-    describe 'filtering of logged url' do
-      it 'filters nothing if config has no keys to be filtered' do
-        config.filter_parameters_in_logged_url.clear
-
-        instrumentation = { url: 'https://example.com/?foo=bar&sensitive=secret' }
-        notify instrumentation
-
-        expect(mock_logger.logged.first).to include 'https://example.com/?foo=bar&sensitive=secret'
-      end
-
-      it 'filters sensitive GET param if config has it in list of params to filter' do
-        config.filter_parameters_in_logged_url << 'sensitive'
-
-        instrumentation = { url: 'https://example.com/?foo=bar&sensitive=secret' }
-        notify instrumentation
-
-        expect(mock_logger.logged.first).to include 'https://example.com/?foo=bar&sensitive=[FILTERED]'
-      end
-
-      it 'filter sensitive GET param does not mutate the url' do
-        config.filter_parameters_in_logged_url << 'sensitive'
-        url = 'https://example.com/?foo=bar&sensitive=secret'
-
-        instrumentation = { url: url }
-        notify instrumentation
-
-        expect(url).to eq 'https://example.com/?foo=bar&sensitive=secret'
-      end
-
-      it 'filters key and signature as defaul from configuration' do
-        instrumentation = { url: 'https://example.com/?key=bar&signature=secret&other=foo' }
-        notify instrumentation
-
-        expect(mock_logger.logged.first).to include 'https://example.com/?key=[FILTERED]&signature=[FILTERED]&other=foo'
-      end
-
-      it 'filters all appearances of a param' do
-        instrumentation = { url: 'https://example.com/?key=bar&key=secret&other=foo' }
-        notify instrumentation
-
-        expect(mock_logger.logged.first).to include 'https://example.com/?key=[FILTERED]&key=[FILTERED]&other=foo'
-      end
     end
   end
 end

--- a/spec/lib/google_distance_matrix/log_subscriber_spec.rb
+++ b/spec/lib/google_distance_matrix/log_subscriber_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module GoogleDistanceMatrix
@@ -9,21 +11,22 @@ module GoogleDistanceMatrix
         @logged = []
       end
 
-      def info(msg, tag)
+      def info(msg, _tag)
         @logged << msg
       end
 
       def error(msg)
-        fail msg
+        raise msg
       end
     end
 
     # Little helper to clean up examples
     def notify(instrumentation)
-      ActiveSupport::Notifications.instrument "client_request_matrix_data.google_distance_matrix", instrumentation do
+      ActiveSupport::Notifications.instrument(
+        'client_request_matrix_data.google_distance_matrix', instrumentation
+      ) do
       end
     end
-
 
     let(:mock_logger) { MockLogger.new }
     let(:config) { Configuration.new }
@@ -32,56 +35,56 @@ module GoogleDistanceMatrix
     before do
       @old_subscribers = LogSubscriber.subscribers.dup
       LogSubscriber.subscribers.clear
-      LogSubscriber.attach_to "google_distance_matrix", LogSubscriber.new(logger: mock_logger, config: config)
+      LogSubscriber.attach_to 'google_distance_matrix',
+                              LogSubscriber.new(logger: mock_logger, config: config)
     end
 
     after do
       @old_subscribers.each do |subscriber|
-        LogSubscriber.attach_to "google_distance_matrix", subscriber
+        LogSubscriber.attach_to 'google_distance_matrix', subscriber
       end
     end
 
-
-    it "logs the url and elements" do
+    it 'logs the url and elements' do
       url = 'https://example.com'
-      instrumentation = {url: url, elements: 0}
+      instrumentation = { url: url, elements: 0 }
 
       expect { notify instrumentation }.to change(mock_logger.logged, :length).from(0).to 1
 
-      expect(mock_logger.logged.first).to include "(elements: 0) GET https://example.com"
+      expect(mock_logger.logged.first).to include '(elements: 0) GET https://example.com'
     end
 
-    describe "filtering of logged url" do
-      it "filters nothing if config has no keys to be filtered" do
+    describe 'filtering of logged url' do
+      it 'filters nothing if config has no keys to be filtered' do
         config.filter_parameters_in_logged_url.clear
 
-        instrumentation = {url: 'https://example.com/?foo=bar&sensitive=secret'}
+        instrumentation = { url: 'https://example.com/?foo=bar&sensitive=secret' }
         notify instrumentation
 
-        expect(mock_logger.logged.first).to include "https://example.com/?foo=bar&sensitive=secret"
+        expect(mock_logger.logged.first).to include 'https://example.com/?foo=bar&sensitive=secret'
       end
 
-      it "filters sensitive GET param if config has it in list of params to filter" do
+      it 'filters sensitive GET param if config has it in list of params to filter' do
         config.filter_parameters_in_logged_url << 'sensitive'
 
-        instrumentation = {url: 'https://example.com/?foo=bar&sensitive=secret'}
+        instrumentation = { url: 'https://example.com/?foo=bar&sensitive=secret' }
         notify instrumentation
 
-        expect(mock_logger.logged.first).to include "https://example.com/?foo=bar&sensitive=[FILTERED]"
+        expect(mock_logger.logged.first).to include 'https://example.com/?foo=bar&sensitive=[FILTERED]'
       end
 
-      it "filters key and signature as defaul from configuration" do
-        instrumentation = {url: 'https://example.com/?key=bar&signature=secret&other=foo'}
+      it 'filters key and signature as defaul from configuration' do
+        instrumentation = { url: 'https://example.com/?key=bar&signature=secret&other=foo' }
         notify instrumentation
 
-        expect(mock_logger.logged.first).to include "https://example.com/?key=[FILTERED]&signature=[FILTERED]&other=foo"
+        expect(mock_logger.logged.first).to include 'https://example.com/?key=[FILTERED]&signature=[FILTERED]&other=foo'
       end
 
-      it "filters all appearances of a param" do
-        instrumentation = {url: 'https://example.com/?key=bar&key=secret&other=foo'}
+      it 'filters all appearances of a param' do
+        instrumentation = { url: 'https://example.com/?key=bar&key=secret&other=foo' }
         notify instrumentation
 
-        expect(mock_logger.logged.first).to include "https://example.com/?key=[FILTERED]&key=[FILTERED]&other=foo"
+        expect(mock_logger.logged.first).to include 'https://example.com/?key=[FILTERED]&key=[FILTERED]&other=foo'
       end
     end
   end

--- a/spec/lib/google_distance_matrix/logger_spec.rb
+++ b/spec/lib/google_distance_matrix/logger_spec.rb
@@ -1,36 +1,39 @@
-require "spec_helper"
+# frozen_string_literal: true
+
+require 'spec_helper'
 
 describe GoogleDistanceMatrix::Logger do
-  context "without a logger backend" do
+  context 'without a logger backend' do
     subject { described_class.new }
 
     described_class::LEVELS.each do |level|
       it "logging #{level} does not fail" do
-        subject.public_send level, "log msg"
+        subject.public_send level, 'log msg'
       end
     end
   end
 
-  context "with a logger backend" do
+  context 'with a logger backend' do
     let(:backend) { double }
 
     subject { described_class.new backend }
 
     described_class::LEVELS.each do |level|
       describe level do
-        it "sends log message to the backend" do
-          expect(backend).to receive(level).with("[google_distance_matrix] log msg")
-          subject.public_send level, "log msg"
+        it 'sends log message to the backend' do
+          expect(backend).to receive(level).with('[google_distance_matrix] log msg')
+          subject.public_send level, 'log msg'
         end
 
-        it "supports sending in a tag" do
-          expect(backend).to receive(level).with("[google_distance_matrix] [client] log msg")
-          subject.public_send level, "log msg", tag: :client
+        it 'supports sending in a tag' do
+          expect(backend).to receive(level).with('[google_distance_matrix] [client] log msg')
+          subject.public_send level, 'log msg', tag: :client
         end
 
-        it "supports sending in multiple tags" do
-          expect(backend).to receive(level).with("[google_distance_matrix] [client] [request] log msg")
-          subject.public_send level, "log msg", tag: ['client', 'request']
+        it 'supports sending in multiple tags' do
+          expect(backend).to receive(level)
+            .with('[google_distance_matrix] [client] [request] log msg')
+          subject.public_send level, 'log msg', tag: %w[client request]
         end
       end
     end

--- a/spec/lib/google_distance_matrix/matrix_spec.rb
+++ b/spec/lib/google_distance_matrix/matrix_spec.rb
@@ -138,11 +138,27 @@ describe GoogleDistanceMatrix::Matrix do
 
       it 'makes one requests to same url' do
         stub = stub_request(:get, url).to_return body: recorded_request_for(:success)
+
         subject.data
         subject.reset!
         subject.data
 
         expect(stub).to have_been_requested.once
+      end
+
+      it 'makes one request when filtered params to same url' do
+        was = GoogleDistanceMatrix.default_configuration.filter_parameters_in_logged_url
+        GoogleDistanceMatrix.default_configuration.filter_parameters_in_logged_url = ['origins']
+
+        stub = stub_request(:get, url).to_return body: recorded_request_for(:success)
+
+        subject.data
+        subject.reset!
+        subject.data
+
+        expect(stub).to have_been_requested.once
+
+        GoogleDistanceMatrix.default_configuration.filter_parameters_in_logged_url = was
       end
 
       it 'clears the cache key on reload' do

--- a/spec/lib/google_distance_matrix/matrix_spec.rb
+++ b/spec/lib/google_distance_matrix/matrix_spec.rb
@@ -10,7 +10,7 @@ describe GoogleDistanceMatrix::Matrix do
   let(:destination_2) { GoogleDistanceMatrix::Place.new address: 'Skjellestadhagen, Heggedal' }
 
   let(:url_builder) { GoogleDistanceMatrix::UrlBuilder.new subject }
-  let(:url) { url_builder.url }
+  let(:url) { url_builder.sensitive_url }
 
   subject do
     described_class.new(

--- a/spec/lib/google_distance_matrix/matrix_spec.rb
+++ b/spec/lib/google_distance_matrix/matrix_spec.rb
@@ -61,6 +61,7 @@ describe GoogleDistanceMatrix::Matrix do
 
   %w[origins destinations].each do |attr|
     let(:place) { GoogleDistanceMatrix::Place.new address: 'My street' }
+    let(:place_2) { GoogleDistanceMatrix::Place.new address: 'Some other street' }
 
     describe "##{attr}" do
       it 'can receive places' do
@@ -72,6 +73,14 @@ describe GoogleDistanceMatrix::Matrix do
         expect do
           2.times { subject.public_send(attr) << place }
         end.to change(subject.public_send(attr), :length).by 1
+      end
+
+      it 'updates the url when adding places' do
+        subject.public_send(attr) << place
+        expect(subject.sensitive_url).to include CGI.escape('My street')
+
+        subject.public_send(attr) << place_2
+        expect(subject.sensitive_url).to include CGI.escape('Some other street')
       end
     end
   end

--- a/spec/lib/google_distance_matrix/place_spec.rb
+++ b/spec/lib/google_distance_matrix/place_spec.rb
@@ -1,23 +1,25 @@
-require "spec_helper"
+# frozen_string_literal: true
+
+require 'spec_helper'
 
 describe GoogleDistanceMatrix::Place do
-  let(:address) { "Karl Johans gate, Oslo" }
+  let(:address) { 'Karl Johans gate, Oslo' }
   let(:lat) { 1.4 }
   let(:lng) { 2.2 }
 
-  describe "#initialize" do
-    it "builds with an address" do
+  describe '#initialize' do
+    it 'builds with an address' do
       place = described_class.new(address: address)
       expect(place.address).to eq address
     end
 
-    it "builds with lat lng" do
+    it 'builds with lat lng' do
       place = described_class.new(lat: lat, lng: lng)
       expect(place.lat).to eq lat
       expect(place.lng).to eq lng
     end
 
-    it "builds with an object responding to lat and lng" do
+    it 'builds with an object responding to lat and lng' do
       point = double lat: 1, lng: 2
       place = described_class.new(point)
 
@@ -25,22 +27,21 @@ describe GoogleDistanceMatrix::Place do
       expect(place.lng).to eq point.lng
     end
 
-
-    it "keeps a record of the object it built itself from" do
+    it 'keeps a record of the object it built itself from' do
       point = double lat: 1, lng: 2
       place = described_class.new(point)
 
       expect(place.extracted_attributes_from).to eq point
     end
-    it "builds with an object responding to address" do
+    it 'builds with an object responding to address' do
       object = double address: address
       place = described_class.new(object)
 
       expect(place.address).to eq object.address
     end
 
-    it "builds with an object responding to lat, lng and address" do
-      object = double lat: 1, lng:2, address: address
+    it 'builds with an object responding to lat, lng and address' do
+      object = double lat: 1, lng: 2, address: address
       place = described_class.new(object)
 
       expect(place.lat).to eq object.lat
@@ -48,46 +49,50 @@ describe GoogleDistanceMatrix::Place do
       expect(place.address).to be_nil
     end
 
-    it "fails if no valid attributes given" do
+    it 'fails if no valid attributes given' do
       expect { described_class.new }.to raise_error ArgumentError
       expect { described_class.new(lat: lat) }.to raise_error ArgumentError
       expect { described_class.new(lng: lng) }.to raise_error ArgumentError
     end
 
-    it "fails if both address, lat ang lng is given" do
-      expect { described_class.new(address: address, lat: lat, lng: lng) }.to raise_error ArgumentError
+    it 'fails if both address, lat ang lng is given' do
+      expect { described_class.new(address: address, lat: lat, lng: lng) }
+        .to raise_error ArgumentError
     end
   end
 
-  describe "#to_param" do
-    context "with address" do
+  describe '#to_param' do
+    context 'with address' do
       subject { described_class.new address: address }
 
       it { expect(subject.to_param).to eq address }
     end
 
-    context "with lat lng" do
+    context 'with lat lng' do
       subject { described_class.new lng: lng, lat: lat }
 
       it { expect(subject.to_param).to eq "#{lat},#{lng}" }
     end
   end
 
-  describe "#equal?" do
-    it "is considered equal when address is the same" do
+  describe '#equal?' do
+    it 'is considered equal when address is the same' do
       expect(described_class.new(address: address)).to be_eql described_class.new(address: address)
     end
 
-    it "is considered equal when lat and lng are the same" do
-      expect(described_class.new(lat: lat, lng: lng)).to be_eql described_class.new(lat: lat, lng: lng)
+    it 'is considered equal when lat and lng are the same' do
+      expect(described_class.new(lat: lat, lng: lng))
+        .to be_eql described_class.new(lat: lat, lng: lng)
     end
 
-    it "is not considered equal when address differs" do
-      expect(described_class.new(address: address)).to_not be_eql described_class.new(address: address + ", Norway")
+    it 'is not considered equal when address differs' do
+      expect(described_class.new(address: address))
+        .to_not be_eql described_class.new(address: address + ', Norway')
     end
 
-    it "is not considered equal when lat or lng differs" do
-      expect(described_class.new(lat: lat, lng: lng)).to_not be_eql described_class.new(lat: lat, lng: lng + 1)
+    it 'is not considered equal when lat or lng differs' do
+      expect(described_class.new(lat: lat, lng: lng))
+        .to_not be_eql described_class.new(lat: lat, lng: lng + 1)
     end
   end
 end

--- a/spec/lib/google_distance_matrix/places_spec.rb
+++ b/spec/lib/google_distance_matrix/places_spec.rb
@@ -1,77 +1,78 @@
-require "spec_helper"
+# frozen_string_literal: true
+
+require 'spec_helper'
 
 describe GoogleDistanceMatrix::Places do
-  let(:values) { [{address: "one"}, {address: "two"}, {address: "three"}] }
+  let(:values) { [{ address: 'one' }, { address: 'two' }, { address: 'three' }] }
   let(:places) { values.map { |v| GoogleDistanceMatrix::Place.new v } }
 
-  let(:place_4) { GoogleDistanceMatrix::Place.new address: "four" }
-  let(:place_5) { GoogleDistanceMatrix::Place.new address: "five" }
-  let(:place_6) { GoogleDistanceMatrix::Place.new address: "six" }
+  let(:place_4) { GoogleDistanceMatrix::Place.new address: 'four' }
+  let(:place_5) { GoogleDistanceMatrix::Place.new address: 'five' }
+  let(:place_6) { GoogleDistanceMatrix::Place.new address: 'six' }
 
   subject { described_class.new places }
 
-  it { should include *places }
+  it { should include(*places) }
   it { should_not include 5 }
 
-
   %w[<< push unshift].each do |attr|
-    describe "#{attr}" do
-      it "adds value" do
-        expect {
+    describe attr.to_s do
+      it 'adds value' do
+        expect do
           subject.public_send attr, place_4
-        }.to change { subject.include? place_4 }.to true
+        end.to change { subject.include? place_4 }.to true
       end
 
-      it "keeps uniq values" do
+      it 'keeps uniq values' do
         subject.public_send attr, place_4
 
-        expect {
+        expect do
           subject.public_send attr, place_4
-        }.to_not change subject, :length
+        end.to_not change subject, :length
       end
 
-      it "is chanable" do
+      it 'is chanable' do
         subject.public_send(attr, place_5).public_send(attr, place_6)
 
         expect(subject).to include place_5, place_6
       end
 
-      it "wraps values in a Place" do
-        subject.public_send attr, {address: "four"}
+      it 'wraps values in a Place' do
+        subject.public_send attr, address: 'four'
 
         expect(subject.all? { |place| place.is_a? GoogleDistanceMatrix::Place }).to be true
-        expect(subject.any? { |place| place.address == "four" }).to be true
+        expect(subject.any? { |place| place.address == 'four' }).to be true
       end
     end
   end
 
   %w[push unshift].each do |attr|
-    describe "#{attr}" do
-      it "adds multiple values at once" do
+    describe attr.to_s do
+      it 'adds multiple values at once' do
         subject.public_send attr, place_4, place_5
         expect(subject).to include place_4, place_5
       end
     end
   end
 
-  describe "#concat" do
+  describe '#concat' do
     let(:places_2) { [place_4, place_5, place_6] }
 
-    it "adds the given array" do
+    it 'adds the given array' do
       subject.concat places_2
-      expect(subject).to include *places_2
+      expect(subject).to include(*places_2)
     end
 
-    it "keeps values uniq" do
+    it 'keeps values uniq' do
       subject.concat places_2
 
-      expect {
+      expect do
         subject.concat places_2
-      }.to_not change subject, :length
+      end.to_not change subject, :length
     end
 
-    it "returns self" do
-      expect(subject.concat places_2).to eq subject
+    it 'returns self' do
+      expect(subject.concat(places_2)).to eq subject
     end
   end
 end

--- a/spec/lib/google_distance_matrix/polyline_encoder/delta_spec.rb
+++ b/spec/lib/google_distance_matrix/polyline_encoder/delta_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module GoogleDistanceMatrix
@@ -6,9 +8,9 @@ module GoogleDistanceMatrix
       deltas = subject.deltas_rounded [[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]]
 
       expect(deltas).to eq [
-        3850000,  -12020000,
-        220000,   -75000,
-        255200,   -550300
+        3_850_000, -12_020_000,
+        220_000,   -75_000,
+        255_200,   -550_300
       ]
     end
   end

--- a/spec/lib/google_distance_matrix/polyline_encoder_spec.rb
+++ b/spec/lib/google_distance_matrix/polyline_encoder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module GoogleDistanceMatrix
@@ -5,12 +7,15 @@ module GoogleDistanceMatrix
     tests = {
       [[-179.9832104, -179.9832104]] => '`~oia@`~oia@',
       [[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]] => '_p~iF~ps|U_ulLnnqC_mqNvxq`@',
-      [[41.3522171071184, -86.0456299662023],[41.3522171071183, -86.0454368471533]] => 'krk{FdxdlO?e@'
+      [
+        [41.3522171071184, -86.0456299662023],
+        [41.3522171071183, -86.0454368471533]
+      ] => 'krk{FdxdlO?e@'
     }
 
     tests.each_pair do |lat_lng_values, expected|
       it "encodes #{lat_lng_values} to #{expected}" do
-        expect(described_class.encode lat_lng_values).to eq expected
+        expect(described_class.encode(lat_lng_values)).to eq expected
       end
     end
   end

--- a/spec/lib/google_distance_matrix/route_spec.rb
+++ b/spec/lib/google_distance_matrix/route_spec.rb
@@ -1,24 +1,26 @@
-require "spec_helper"
+# frozen_string_literal: true
+
+require 'spec_helper'
 
 describe GoogleDistanceMatrix::Route do
   let(:attributes) do
     {
-      "distance" => {"text" => "2.0 km", "value" => 2032},
-      "duration" => {"text" =>"6 mins",  "value" => 367},
-      "duration_in_traffic" => {"text" =>"5 mins",  "value" => 301},
-      "status" =>"OK"
+      'distance' => { 'text' => '2.0 km', 'value' => 2032 },
+      'duration' => { 'text' => '6 mins',  'value' => 367 },
+      'duration_in_traffic' => { 'text' => '5 mins',  'value' => 301 },
+      'status' => 'OK'
     }
   end
 
   subject { described_class.new attributes }
 
-  it { expect(subject.status).to eq "ok" }
+  it { expect(subject.status).to eq 'ok' }
   it { expect(subject.distance_in_meters).to eq 2032 }
-  it { expect(subject.distance_text).to eq "2.0 km" }
+  it { expect(subject.distance_text).to eq '2.0 km' }
   it { expect(subject.duration_in_seconds).to eq 367 }
-  it { expect(subject.duration_text).to eq "6 mins" }
+  it { expect(subject.duration_text).to eq '6 mins' }
   it { expect(subject.duration_in_traffic_in_seconds).to eq 301 }
-  it { expect(subject.duration_in_traffic_text).to eq "5 mins" }
+  it { expect(subject.duration_in_traffic_text).to eq '5 mins' }
 
   it { is_expected.to be_ok }
 end

--- a/spec/lib/google_distance_matrix/routes_finder_spec.rb
+++ b/spec/lib/google_distance_matrix/routes_finder_spec.rb
@@ -1,16 +1,18 @@
-require "spec_helper"
+# frozen_string_literal: true
+
+require 'spec_helper'
 
 describe GoogleDistanceMatrix::RoutesFinder, :request_recordings do
-  let(:origin_1) { GoogleDistanceMatrix::Place.new address: "Karl Johans gate, Oslo" }
-  let(:origin_2) { GoogleDistanceMatrix::Place.new address: "Askerveien 1, Asker" }
+  let(:origin_1) { GoogleDistanceMatrix::Place.new address: 'Karl Johans gate, Oslo' }
+  let(:origin_2) { GoogleDistanceMatrix::Place.new address: 'Askerveien 1, Asker' }
 
-  let(:destination_1) { GoogleDistanceMatrix::Place.new address: "Drammensveien 1, Oslo" }
+  let(:destination_1) { GoogleDistanceMatrix::Place.new address: 'Drammensveien 1, Oslo' }
 
-  let(:destination_2_built_from) { double address: "Skjellestadhagen, Heggedal" }
+  let(:destination_2_built_from) { double address: 'Skjellestadhagen, Heggedal' }
   let(:destination_2) { GoogleDistanceMatrix::Place.new destination_2_built_from }
 
   let(:url_builder) { GoogleDistanceMatrix::UrlBuilder.new matrix }
-  let(:url) { url_builder.url }
+  let(:url) { url_builder.sensitive_url }
 
   let(:matrix) do
     GoogleDistanceMatrix::Matrix.new(
@@ -21,55 +23,61 @@ describe GoogleDistanceMatrix::RoutesFinder, :request_recordings do
 
   subject { described_class.new matrix }
 
-  context "success, with traffic data" do
+  context 'success, with traffic data' do
     before do
       matrix.configure do |c|
         c.departure_time = 'now'
       end
     end
 
-    let!(:api_request_stub) { stub_request(:get, url).to_return body: recorded_request_for(:success_with_in_traffic) }
+    let!(:api_request_stub) do
+      stub_request(:get, url).to_return body: recorded_request_for(:success_with_in_traffic)
+    end
 
-    describe "#shortest_route_by_duration_in_traffic_to" do
-      it "returns route representing shortest duration to given origin" do
+    describe '#shortest_route_by_duration_in_traffic_to' do
+      it 'returns route representing shortest duration to given origin' do
         expect(subject.shortest_route_by_duration_in_traffic_to(origin_1)).to eq matrix.data[0][0]
       end
 
-      it "returns route representing shortest duration to given destination" do
-        expect(subject.shortest_route_by_duration_in_traffic_to(destination_2)).to eq matrix.data[1][1]
+      it 'returns route representing shortest duration to given destination' do
+        expect(subject.shortest_route_by_duration_in_traffic_to(destination_2))
+          .to eq matrix.data[1][1]
       end
     end
 
-    describe "#shortest_route_by_duration_in_traffic_to!" do
-      it "returns the same as shortest_route_by_duration_in_traffic_to" do
-        expect(subject.shortest_route_by_duration_in_traffic_to!(origin_1)).to eq subject.shortest_route_by_duration_in_traffic_to(origin_1)
+    describe '#shortest_route_by_duration_in_traffic_to!' do
+      it 'returns the same as shortest_route_by_duration_in_traffic_to' do
+        expect(subject.shortest_route_by_duration_in_traffic_to!(origin_1))
+          .to eq subject.shortest_route_by_duration_in_traffic_to(origin_1)
       end
     end
   end
 
-  context "success, without in traffic data" do
-    let!(:api_request_stub) { stub_request(:get, url).to_return body: recorded_request_for(:success) }
+  context 'success, without in traffic data' do
+    let!(:api_request_stub) do
+      stub_request(:get, url).to_return body: recorded_request_for(:success)
+    end
 
-    describe "#routes_for" do
-      it "fails if given place does not exist" do
-        expect { subject.routes_for "foo" }.to raise_error ArgumentError
+    describe '#routes_for' do
+      it 'fails if given place does not exist' do
+        expect { subject.routes_for 'foo' }.to raise_error ArgumentError
       end
 
-      it "returns routes for given origin" do
+      it 'returns routes for given origin' do
         routes = subject.routes_for origin_1
 
         expect(routes.length).to eq 2
         expect(routes.map(&:origin).all? { |o| o == origin_1 }).to be true
       end
 
-      it "returns routes for given destination" do
+      it 'returns routes for given destination' do
         routes = subject.routes_for destination_2
 
         expect(routes.length).to eq 2
         expect(routes.map(&:destination).all? { |d| d == destination_2 }).to be true
       end
 
-      it "returns routes for given object a place was built from" do
+      it 'returns routes for given object a place was built from' do
         routes = subject.routes_for destination_2_built_from
 
         expect(routes.length).to eq 2
@@ -77,40 +85,42 @@ describe GoogleDistanceMatrix::RoutesFinder, :request_recordings do
       end
     end
 
-    describe "#routes_for!" do
-      it "returns the same as routes_for" do
-        expect(subject.routes_for! origin_1).to eq subject.routes_for(origin_1)
+    describe '#routes_for!' do
+      it 'returns the same as routes_for' do
+        expect(subject.routes_for!(origin_1)).to eq subject.routes_for(origin_1)
       end
     end
 
-    describe "#route_for" do
-      it "returns route" do
+    describe '#route_for' do
+      it 'returns route' do
         route = subject.route_for(origin: origin_1, destination: destination_1)
         expect(route.origin).to eq origin_1
         expect(route.destination).to eq destination_1
       end
 
-      it "returns route when you give it the object a place was built from" do
+      it 'returns route when you give it the object a place was built from' do
         route = subject.route_for(origin: origin_1, destination: destination_2_built_from)
         expect(route.origin).to eq origin_1
         expect(route.destination).to eq destination_2
       end
 
-      it "fails with argument error if origin is missing" do
+      it 'fails with argument error if origin is missing' do
         expect { subject.route_for destination: destination_2 }.to raise_error ArgumentError
       end
 
-      it "fails with argument error if destination is missing" do
+      it 'fails with argument error if destination is missing' do
         expect { subject.route_for origin: origin_1 }.to raise_error ArgumentError
       end
 
-      it "fails with argument error if sent in object is neither place nor something it was built from" do
-        expect { subject.route_for origin: origin_1, destination: double }.to raise_error ArgumentError
+      it 'fails with argument error if object is neither place nor something it was built from' do
+        expect do
+          subject.route_for origin: origin_1, destination: double
+        end.to raise_error ArgumentError
       end
     end
 
-    describe "#route_for!" do
-      it "returns the same as route_for" do
+    describe '#route_for!' do
+      it 'returns the same as route_for' do
         route = subject.route_for(origin: origin_1, destination: destination_1)
         route_bang = subject.route_for!(origin: origin_1, destination: destination_1)
 
@@ -118,60 +128,64 @@ describe GoogleDistanceMatrix::RoutesFinder, :request_recordings do
       end
     end
 
-    describe "#shortest_route_by_distance_to" do
-      it "returns route representing shortest distance to given origin" do
+    describe '#shortest_route_by_distance_to' do
+      it 'returns route representing shortest distance to given origin' do
         expect(subject.shortest_route_by_distance_to(origin_1)).to eq matrix.data[0][0]
       end
 
-      it "returns route representing shortest distance to given destination" do
+      it 'returns route representing shortest distance to given destination' do
         expect(subject.shortest_route_by_distance_to(destination_2)).to eq matrix.data[1][1]
       end
     end
 
-    describe "#shortest_route_by_distance_to!" do
-      it "returns the same as shortest_route_by_distance_to" do
-        expect(subject.shortest_route_by_distance_to!(origin_1)).to eq subject.shortest_route_by_distance_to(origin_1)
+    describe '#shortest_route_by_distance_to!' do
+      it 'returns the same as shortest_route_by_distance_to' do
+        expect(subject.shortest_route_by_distance_to!(origin_1))
+          .to eq subject.shortest_route_by_distance_to(origin_1)
       end
     end
 
-    describe "#shortest_route_by_duration_to" do
-      it "returns route representing shortest duration to given origin" do
+    describe '#shortest_route_by_duration_to' do
+      it 'returns route representing shortest duration to given origin' do
         expect(subject.shortest_route_by_duration_to(origin_1)).to eq matrix.data[0][0]
       end
 
-      it "returns route representing shortest duration to given destination" do
+      it 'returns route representing shortest duration to given destination' do
         expect(subject.shortest_route_by_duration_to(destination_2)).to eq matrix.data[1][1]
       end
     end
 
-    describe "#shortest_route_by_duration_to!" do
-      it "returns the same as shortest_route_by_duration_to" do
-        expect(subject.shortest_route_by_duration_to!(origin_1)).to eq subject.shortest_route_by_duration_to(origin_1)
+    describe '#shortest_route_by_duration_to!' do
+      it 'returns the same as shortest_route_by_duration_to' do
+        expect(subject.shortest_route_by_duration_to!(origin_1))
+          .to eq subject.shortest_route_by_duration_to(origin_1)
       end
     end
 
-    describe "#shortest_route_by_duration_in_traffic_to" do
-      it "returns route representing shortest duration to given origin" do
-        expect {
+    describe '#shortest_route_by_duration_in_traffic_to' do
+      it 'returns route representing shortest duration to given origin' do
+        expect do
           subject.shortest_route_by_duration_in_traffic_to(origin_1)
-        }.to raise_error GoogleDistanceMatrix::InvalidQuery
+        end.to raise_error GoogleDistanceMatrix::InvalidQuery
       end
     end
 
-    describe "#shortest_route_by_duration_in_traffic_to!" do
-      it "returns the same as shortest_route_by_duration_in_traffic_to" do
-        expect {
+    describe '#shortest_route_by_duration_in_traffic_to!' do
+      it 'returns the same as shortest_route_by_duration_in_traffic_to' do
+        expect do
           subject.shortest_route_by_duration_in_traffic_to!(origin_1)
-        }.to raise_error GoogleDistanceMatrix::InvalidQuery
+        end.to raise_error GoogleDistanceMatrix::InvalidQuery
       end
     end
   end
 
-  context "routes mssing data" do
-    let!(:api_request_stub) { stub_request(:get, url).to_return body: recorded_request_for(:zero_results) }
+  context 'routes mssing data' do
+    let!(:api_request_stub) do
+      stub_request(:get, url).to_return body: recorded_request_for(:zero_results)
+    end
 
-    describe "#routes_for" do
-      it "returns routes for given origin" do
+    describe '#routes_for' do
+      it 'returns routes for given origin' do
         routes = subject.routes_for origin_1
 
         expect(routes.length).to eq 2
@@ -179,53 +193,53 @@ describe GoogleDistanceMatrix::RoutesFinder, :request_recordings do
       end
     end
 
-    describe "#routes_for!" do
-      it "fails upon any non-ok route" do
-        expect {
+    describe '#routes_for!' do
+      it 'fails upon any non-ok route' do
+        expect do
           subject.routes_for! origin_1
-        }.to raise_error GoogleDistanceMatrix::InvalidRoute
+        end.to raise_error GoogleDistanceMatrix::InvalidRoute
       end
     end
 
-
-    describe "#route_for" do
-      it "returns route" do
+    describe '#route_for' do
+      it 'returns route' do
         route = subject.route_for origin: origin_1, destination: destination_2
         expect(route.origin).to eq origin_1
         expect(route.destination).to eq destination_2
       end
     end
 
-    describe "#route_for!" do
-      it "fails upon non-ok route" do
-        expect {
+    describe '#route_for!' do
+      it 'fails upon non-ok route' do
+        expect do
           subject.route_for! origin: origin_1, destination: destination_2
-        }.to raise_error GoogleDistanceMatrix::InvalidRoute
+        end.to raise_error GoogleDistanceMatrix::InvalidRoute
       end
     end
 
-
-    describe "#shortest_route_by_distance_to" do
-      it "returns route representing shortest distance to given origin" do
+    describe '#shortest_route_by_distance_to' do
+      it 'returns route representing shortest distance to given origin' do
         expect(subject.shortest_route_by_distance_to(origin_1)).to eq matrix.data[0][0]
       end
     end
 
-    describe "#shortest_route_by_distance_to!" do
-      it "fails upon non-ok route" do
-        expect { subject.shortest_route_by_distance_to!(origin_1) }.to raise_error GoogleDistanceMatrix::InvalidRoute
+    describe '#shortest_route_by_distance_to!' do
+      it 'fails upon non-ok route' do
+        expect { subject.shortest_route_by_distance_to!(origin_1) }
+          .to raise_error GoogleDistanceMatrix::InvalidRoute
       end
     end
 
-    describe "#shortest_route_by_duration_to" do
-      it "returns route representing shortest distance to given origin" do
+    describe '#shortest_route_by_duration_to' do
+      it 'returns route representing shortest distance to given origin' do
         expect(subject.shortest_route_by_duration_to(origin_1)).to eq matrix.data[0][0]
       end
     end
 
-    describe "#shortest_route_by_duration_to!" do
-      it "fails upon non-ok route" do
-        expect { subject.shortest_route_by_duration_to!(origin_1) }.to raise_error GoogleDistanceMatrix::InvalidRoute
+    describe '#shortest_route_by_duration_to!' do
+      it 'fails upon non-ok route' do
+        expect { subject.shortest_route_by_duration_to!(origin_1) }
+          .to raise_error GoogleDistanceMatrix::InvalidRoute
       end
     end
   end

--- a/spec/lib/google_distance_matrix/url_builder_spec.rb
+++ b/spec/lib/google_distance_matrix/url_builder_spec.rb
@@ -51,24 +51,25 @@ describe GoogleDistanceMatrix::UrlBuilder do
 
       expect(subject).to receive(:query_params_string).and_return long_string
 
-      expect { subject.url }.to raise_error GoogleDistanceMatrix::MatrixUrlTooLong
+      expect { subject.sensitive_url }.to raise_error GoogleDistanceMatrix::MatrixUrlTooLong
     end
 
     it 'starts with the base URL' do
-      expect(subject.url).to start_with 'https://' + described_class::BASE_URL
+      expect(subject.sensitive_url).to start_with 'https://' + described_class::BASE_URL
     end
 
     it 'has a configurable protocol' do
       matrix.configure { |c| c.protocol = 'http' }
-      expect(subject.url).to start_with 'http://'
+      expect(subject.sensitive_url).to start_with 'http://'
     end
 
     it 'includes origins' do
-      expect(subject.url).to include "origins=address_origin_1#{delimiter}address_origin_2"
+      expect(subject.sensitive_url)
+        .to include "origins=address_origin_1#{delimiter}address_origin_2"
     end
 
     it 'includes destinations' do
-      expect(subject.url).to include "destinations=1#{comma}11#{delimiter}2#{comma}22"
+      expect(subject.sensitive_url).to include "destinations=1#{comma}11#{delimiter}2#{comma}22"
     end
 
     describe 'lat lng scale' do
@@ -77,7 +78,7 @@ describe GoogleDistanceMatrix::UrlBuilder do
       it 'rounds lat and lng' do
         subject.matrix.configure { |c| c.lat_lng_scale = 5 }
 
-        expect(subject.url).to include "destinations=10.12346#{comma}10.98765"
+        expect(subject.sensitive_url).to include "destinations=10.12346#{comma}10.98765"
       end
     end
 
@@ -91,13 +92,13 @@ describe GoogleDistanceMatrix::UrlBuilder do
       end
 
       it 'includes places with addresses as addresses' do
-        expect(subject.url).to include "origins=address_origin_1#{delimiter}address_origin_2"
+        expect(subject.sensitive_url).to include "origins=address_origin_1#{delimiter}address_origin_2"
       end
 
       it(
         'encodes places with lat/lng values togheter, broken up by addresses to keep places order'
       ) do
-        expect(subject.url).to include(
+        expect(subject.sensitive_url).to include(
           # 2 first places encoded togheter as they have lat lng values
           "destinations=enc#{colon}_ibE_mcbA_ibE_mcbA#{colon}#{delimiter}" +
           # encoded polyline broken off by a destination with address
@@ -117,7 +118,7 @@ describe GoogleDistanceMatrix::UrlBuilder do
         end
 
         it 'includes the api key' do
-          expect(subject.url).to include "key=#{matrix.configuration.google_api_key}"
+          expect(subject.sensitive_url).to include "key=#{matrix.configuration.google_api_key}"
         end
       end
 
@@ -130,12 +131,12 @@ describe GoogleDistanceMatrix::UrlBuilder do
         end
 
         it 'includes client' do
-          expect(subject.url)
+          expect(subject.sensitive_url)
             .to include "client=#{matrix.configuration.google_business_api_client_id}"
         end
 
         it 'has signature' do
-          expect(subject.url).to include 'signature=DIUgkQ_BaVBJU6hwhzH3GLeMdeo='
+          expect(subject.sensitive_url).to include 'signature=DIUgkQ_BaVBJU6hwhzH3GLeMdeo='
         end
       end
     end

--- a/spec/lib/google_distance_matrix/url_builder_spec.rb
+++ b/spec/lib/google_distance_matrix/url_builder_spec.rb
@@ -1,12 +1,14 @@
-require "spec_helper"
+# frozen_string_literal: true
+
+require 'spec_helper'
 
 describe GoogleDistanceMatrix::UrlBuilder do
   let(:delimiter) { described_class::DELIMITER }
-  let(:comma) { CGI.escape "," }
-  let(:colon) { CGI.escape ":" }
+  let(:comma) { CGI.escape ',' }
+  let(:colon) { CGI.escape ':' }
 
-  let(:origin_1) { GoogleDistanceMatrix::Place.new address: "address_origin_1" }
-  let(:origin_2) { GoogleDistanceMatrix::Place.new address: "address_origin_2" }
+  let(:origin_1) { GoogleDistanceMatrix::Place.new address: 'address_origin_1' }
+  let(:origin_2) { GoogleDistanceMatrix::Place.new address: 'address_origin_2' }
 
   let(:destination_1) { GoogleDistanceMatrix::Place.new lat: 1, lng: 11 }
   let(:destination_2) { GoogleDistanceMatrix::Place.new lat: 2, lng: 22 }
@@ -23,65 +25,64 @@ describe GoogleDistanceMatrix::UrlBuilder do
 
   subject { described_class.new matrix }
 
-  describe "#initialize" do
-    it "has a matrix" do
+  describe '#initialize' do
+    it 'has a matrix' do
       expect(described_class.new(matrix).matrix).to eq matrix
     end
 
-    it "fails if matrix is invalid" do
-      expect {
+    it 'fails if matrix is invalid' do
+      expect do
         described_class.new GoogleDistanceMatrix::Matrix.new
-      }.to raise_error GoogleDistanceMatrix::InvalidMatrix
+      end.to raise_error GoogleDistanceMatrix::InvalidMatrix
     end
 
     it "fails if matrix's configuration is invalid" do
-      expect {
+      expect do
         matrix.configure { |c| c.mode = 'foobar' }
         described_class.new matrix
-      }.to raise_error GoogleDistanceMatrix::InvalidMatrix
+      end.to raise_error GoogleDistanceMatrix::InvalidMatrix
     end
   end
 
+  describe '#url' do
+    it 'fails if the url is more than 2048 characters' do
+      long_string = ''.dup
+      2049.times { long_string << 'a' }
 
-  describe "#url" do
-    it "fails if the url is more than 2048 characters" do
-      long_string = ""
-      2049.times { long_string << "a" }
-
-      allow(subject).to receive(:get_params_string).and_return long_string
+      expect(subject).to receive(:query_params_string).and_return long_string
 
       expect { subject.url }.to raise_error GoogleDistanceMatrix::MatrixUrlTooLong
     end
 
-    it "starts with the base URL" do
-      expect(subject.url).to start_with "https://" + described_class::BASE_URL
+    it 'starts with the base URL' do
+      expect(subject.url).to start_with 'https://' + described_class::BASE_URL
     end
 
-    it "has a configurable protocol" do
-      matrix.configure { |c| c.protocol = "http" }
-      expect(subject.url).to start_with "http://"
+    it 'has a configurable protocol' do
+      matrix.configure { |c| c.protocol = 'http' }
+      expect(subject.url).to start_with 'http://'
     end
 
-    it "includes origins" do
+    it 'includes origins' do
       expect(subject.url).to include "origins=address_origin_1#{delimiter}address_origin_2"
     end
 
-    it "includes destinations" do
+    it 'includes destinations' do
       expect(subject.url).to include "destinations=1#{comma}11#{delimiter}2#{comma}22"
     end
 
-    describe "lat lng scale" do
-      let(:destination_1) { GoogleDistanceMatrix::Place.new lat: 10.123456789, lng: "10.987654321" }
+    describe 'lat lng scale' do
+      let(:destination_1) { GoogleDistanceMatrix::Place.new lat: 10.123456789, lng: '10.987654321' }
 
-      it "rounds lat and lng" do
+      it 'rounds lat and lng' do
         subject.matrix.configure { |c| c.lat_lng_scale = 5 }
 
         expect(subject.url).to include "destinations=10.12346#{comma}10.98765"
       end
     end
 
-    describe "use encoded polylines" do
-      let(:destination_3) { GoogleDistanceMatrix::Place.new address: "address_destination_3" }
+    describe 'use encoded polylines' do
+      let(:destination_3) { GoogleDistanceMatrix::Place.new address: 'address_destination_3' }
       let(:destination_4) { GoogleDistanceMatrix::Place.new lat: 4, lng: 44 }
       let(:destinations) { [destination_1, destination_2, destination_3, destination_4] }
 
@@ -89,11 +90,13 @@ describe GoogleDistanceMatrix::UrlBuilder do
         matrix.configure { |c| c.use_encoded_polylines = true }
       end
 
-      it "includes places with addresses as addresses" do
+      it 'includes places with addresses as addresses' do
         expect(subject.url).to include "origins=address_origin_1#{delimiter}address_origin_2"
       end
 
-      it "encodes places with lat/lng values togheter, broken up by addresses to keep places order" do
+      it(
+        'encodes places with lat/lng values togheter, broken up by addresses to keep places order'
+      ) do
         expect(subject.url).to include(
           # 2 first places encoded togheter as they have lat lng values
           "destinations=enc#{colon}_ibE_mcbA_ibE_mcbA#{colon}#{delimiter}" +
@@ -105,7 +108,7 @@ describe GoogleDistanceMatrix::UrlBuilder do
       end
     end
 
-    describe "configuration" do
+    describe 'configuration' do
       context 'with google api key set' do
         before do
           matrix.configure do |config|
@@ -118,20 +121,21 @@ describe GoogleDistanceMatrix::UrlBuilder do
         end
       end
 
-      context "with google business client id and private key set" do
+      context 'with google business client id and private key set' do
         before do
           matrix.configure do |config|
-            config.google_business_api_client_id = "123"
-            config.google_business_api_private_key = "c2VjcmV0"
+            config.google_business_api_client_id = '123'
+            config.google_business_api_private_key = 'c2VjcmV0'
           end
         end
 
-        it "includes client" do
-          expect(subject.url).to include "client=#{matrix.configuration.google_business_api_client_id}"
+        it 'includes client' do
+          expect(subject.url)
+            .to include "client=#{matrix.configuration.google_business_api_client_id}"
         end
 
-        it "has signature" do
-          expect(subject.url).to include "signature=DIUgkQ_BaVBJU6hwhzH3GLeMdeo="
+        it 'has signature' do
+          expect(subject.url).to include 'signature=DIUgkQ_BaVBJU6hwhzH3GLeMdeo='
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 require 'google_distance_matrix'
 
@@ -15,7 +17,7 @@ module RecordedRequestHelpers
   private
 
   def path_to(name)
-    File.join File.dirname(__FILE__), "request_recordings", name.to_s
+    File.join File.dirname(__FILE__), 'request_recordings', name.to_s
   end
 end
 


### PR DESCRIPTION
This fixes an issue where filtering the URL actually mutated the given URL string. That string was also used as a cache key, but it didn't hit the cache as the string was mutated.

Fixes https://github.com/Skalar/google_distance_matrix/issues/32

PS. There are ~~some~~ a lot of rubocop related changes in this pull request as well as the fix. Sorry for that, but I didn't spend time keeping the rubocop commits separate from the fix.