### PR TITLE
Support a timeout for HTTP calls

### DIFF
--- a/lib/google_distance_matrix/configuration.rb
+++ b/lib/google_distance_matrix/configuration.rb
@@ -18,7 +18,7 @@ module GoogleDistanceMatrix
       mode avoid units language
       departure_time arrival_time
       transit_mode transit_routing_preference
-      traffic_model channel
+      traffic_model channel timeout
     ].freeze
 
     API_DEFAULTS = {
@@ -79,6 +79,8 @@ module GoogleDistanceMatrix
               allow_blank: true
 
     validates :protocol, inclusion: { in: %w[http https] }, allow_blank: true
+
+    validates :timeout, numericality: true, allow_blank: true
 
     def initialize
       API_DEFAULTS.each_pair do |attr_name, value|

--- a/spec/lib/google_distance_matrix/configuration_spec.rb
+++ b/spec/lib/google_distance_matrix/configuration_spec.rb
@@ -90,6 +90,7 @@ describe GoogleDistanceMatrix::Configuration do
 
     it { expect(subject.logger).to be_nil }
     it { expect(subject.cache).to be_nil }
+    it { expect(subject.timeout).to be_nil }
 
     # rubocop:disable Metrics/LineLength
     it 'has a default expected cache_key_transform' do


### PR DESCRIPTION
By default Net::HTTP sets open and read timeouts to 60s, which can be dangerous if you're experiencing network issues and your server hangs (happened to me recently 😬 still not sure if the timeout was due to network or Google themselves).

Taking an optional timeout in the distance matrix configuration here.