### PR TITLE
Loose patch version restriction to support newer rails versions

### DIFF
--- a/google_distance_matrix.gemspec
+++ b/google_distance_matrix.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activemodel', '>= 3.2.13', '<= 5.2.1'
-  spec.add_dependency 'activesupport', '>= 3.2.13', '<= 5.2.1'
+  spec.add_dependency 'activemodel', '>= 3.2.13', '< 5.3'
+  spec.add_dependency 'activesupport', '>= 3.2.13', '< 5.3'
   spec.add_dependency 'google_business_api_url_signer', '~> 0.1.3'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
I'm unable to use latest version of this gem in a project running in Rails `5.2.2.1` which is the latest non-beta released version of it.

I have loosen both `activemodel` and `activesupport` restrictions to be able to do that.
Gem behaves as expected in such context after testing it and running existing specs.