### PR TITLE
Support for Rails 6.1.

### DIFF
--- a/google_distance_matrix.gemspec
+++ b/google_distance_matrix.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activemodel', '>= 3.2.13', '< 6.1'
-  spec.add_dependency 'activesupport', '>= 3.2.13', '< 6.1'
+  spec.add_dependency 'activemodel', '>= 3.2.13', '< 6.2'
+  spec.add_dependency 'activesupport', '>= 3.2.13', '< 6.2'
   spec.add_dependency 'google_business_api_url_signer', '~> 0.1.3'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
## Changes:
* Bumps the pinned version of ActiveModel and ActiveSupport to `< 6.2`.

## Comments:
Test suite passed with these updated gem versions without any failures, and having reviewed the changelogs for both ActiveModel and ActiveSupport, there shouldn't be anything in there that causes issue.

This also seems to cause no issues in the test suite of one of our production applications.
