### PR TITLE
Bump dependencies for Rails 7.0

### DIFF
--- a/google_distance_matrix.gemspec
+++ b/google_distance_matrix.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activemodel', '>= 3.2.13', '< 6.2'
-  spec.add_dependency 'activesupport', '>= 3.2.13', '< 6.2'
+  spec.add_dependency 'activemodel', '>= 3.2.13', '< 7.1'
+  spec.add_dependency 'activesupport', '>= 3.2.13', '< 7.1'
   spec.add_dependency 'google_business_api_url_signer', '~> 0.1.3'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
Bumps activemodel and activesupport dependency ranges to allow Rails 7.0.