### PR TITLE
Bump dependencies for Rails 7.1

### DIFF
--- a/google_distance_matrix.gemspec
+++ b/google_distance_matrix.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activemodel', '>= 3.2.13', '< 7.1'
-  spec.add_dependency 'activesupport', '>= 3.2.13', '< 7.1'
+  spec.add_dependency 'activemodel', '>= 3.2.13', '< 7.2'
+  spec.add_dependency 'activesupport', '>= 3.2.13', '< 7.2'
   spec.add_dependency 'google_business_api_url_signer', '~> 0.1.3'
 
   spec.add_development_dependency 'bundler'

--- a/google_distance_matrix.gemspec
+++ b/google_distance_matrix.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec', '~> 3.8.0'
+  spec.add_development_dependency 'rspec', '~> 3.12.0'
   spec.add_development_dependency 'rubocop', '~> 0.59.2'
   spec.add_development_dependency 'shoulda-matchers', '~> 4.0.0.rc1'
   spec.add_development_dependency 'webmock', '~> 3.4.2'

--- a/lib/google_distance_matrix/logger.rb
+++ b/lib/google_distance_matrix/logger.rb
@@ -24,7 +24,7 @@ module GoogleDistanceMatrix
     end
 
     def level
-      backend&.level
+      backend&.level || 1
     end
 
     private

--- a/lib/google_distance_matrix/logger.rb
+++ b/lib/google_distance_matrix/logger.rb
@@ -23,6 +23,10 @@ module GoogleDistanceMatrix
       end
     end
 
+    def level
+      backend&.level
+    end
+
     private
 
     def tag_msg(msg, tags)

--- a/spec/lib/google_distance_matrix/log_subscriber_spec.rb
+++ b/spec/lib/google_distance_matrix/log_subscriber_spec.rb
@@ -18,6 +18,10 @@ module GoogleDistanceMatrix
       def error(msg)
         raise msg
       end
+
+      def level
+        1
+      end
     end
 
     # Little helper to clean up examples


### PR DESCRIPTION
Bumps activemodel and activesupport dependency ranges to allow Rails 7.1, which was released two weeks ago.